### PR TITLE
Restore helix renderer with clean docs

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,73 +3,23 @@
 Static HTML + Canvas scene layering sacred geometry. Works offline and avoids motion for ND safety.
 
 ## Files
-- `index.html` – entry point; open directly in a browser.
+- `index.html` – entry page; open directly in a modern browser.
 - `js/helix-renderer.mjs` – ES module with pure drawing routines.
 - `data/palette.json` – optional colors; missing file triggers a calm fallback.
+- `README_RENDERER.md` – this guide.
 
 ## Usage
-1. Keep the three files together.
+1. Keep the files together.
 2. Double-click `index.html` (no server or network needed).
 3. Canvas renders:
    - Vesica field
-   - Tree-of-Life nodes and paths
+   - Tree-of-Life scaffold
    - Fibonacci curve
    - Static double-helix lattice
 4. If `palette.json` is absent, a notice appears and safe default colors are used.
 
-## ND-safe choices
-- No animation or autoplay.
-- Calm contrast and soft tones.
-- Layer order preserves depth without flattening.
-- Geometry uses numerology constants `3, 7, 9, 11, 22, 33, 99, 144` for proportions.
-
-Static offline HTML+Canvas sketch encoding a layered cosmology. ND-safe: no motion, no network, soft contrast.
-
-## Layers
-1. **Vesica field** – intersecting circles grid.
-2. **Tree-of-Life** – ten sephirot with twenty-two paths.
-3. **Fibonacci curve** – static logarithmic spiral.
-Static, ND-safe HTML+Canvas scene layering four forms of sacred geometry. Works fully offline.
-
-## Layers
-1. **Vesica field** – intersecting circles forming a calm grid.
-2. **Tree-of-Life scaffold** – ten nodes and twenty-two paths.
-3. **Fibonacci curve** – logarithmic spiral polyline.
-4. **Double-helix lattice** – two sine strands with crossbars.
-
-## Usage
-1. Keep `index.html`, `js/helix-renderer.mjs`, and `data/palette.json` together.
-2. Double-click `index.html` in any modern browser.
-3. If `palette.json` is missing, a calm fallback palette is used and a note appears in the header.
-
 ## Palette
-```
-Static, offline Canvas scene with layered sacred geometry. No motion, no dependencies.
-
-## Files
-- `index.html` — entry page; open directly.
-- `js/helix-renderer.mjs` — ES module with drawing routines.
-- `data/palette.json` — optional palette; missing file triggers fallback.
-- `README_RENDERER.md` — this guide.
-
-## Usage
-1. Keep the three files in one folder.
-2. Double-click `index.html` in a modern browser.
-3. A 1440x900 canvas draws:
-   - Vesica circle field
-   - Tree-of-Life nodes and paths
-   - Fibonacci spiral polyline
-   - Static double-helix lattice
-
-If `data/palette.json` is absent, a notice appears and a safe palette is used.
-
-## Palette
-`palette.json` structure:
-2. Double-click `index.html` in any modern browser (no server or network).
-3. If `palette.json` is missing, a fallback palette is used and noted inline.
-
-## Palette
-`data/palette.json` contains colors:
+`data/palette.json` structure:
 ```json
 {
   "bg": "#0b0b12",
@@ -77,22 +27,10 @@ If `data/palette.json` is absent, a notice appears and a safe palette is used.
   "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 }
 ```
-Edit `data/palette.json` to customize colors or remove it to test the fallback.
+Edit the file to customize colors or remove it to test the fallback.
 
-## ND-safe Choices
-- No animation or flashing elements.
-- Calm contrast and generous spacing for readability.
-- Geometry counts use numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
-- Layer order preserves depth without flattening.
 ## ND-safe choices
 - No animation or flashing elements.
 - Calm contrast and soft tones.
-- Layer order (Vesica -> Tree -> Fibonacci -> Helix) preserves depth without 3D.
-- Geometry uses numerology constants 3, 7, 9, 11, 22, 33, 99, and 144 for proportion.
-Edit values to customize hues.
-
-## ND-safe choices
-- No motion or autoplay; scene renders once.
-- Soft contrast with readable tones.
-- Geometry counts and proportions use numerology constants `3,7,9,11,22,33,99,144`.
-- Layer order preserves depth without flattening geometry.
+- Geometry counts use numerology constants `3, 7, 9, 11, 22, 33, 99, 144`.
+- Layer order (Vesica → Tree → Fibonacci → Helix) preserves depth without flattening.

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -2,83 +2,20 @@
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-  Static, ND-safe drawing routines for layered sacred geometry.
   Layers (back to front):
-    1) Vesica field
-    2) Tree-of-Life scaffold
-    3) Fibonacci curve
-    4) Static double-helix lattice
+    1) Vesica field (intersecting circle grid)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
+    3) Fibonacci curve (log spiral polyline)
+    4) Double-helix lattice (two phase-shifted sine strands with crossbars)
 
   No animation, network calls, or external libraries.
-  Geometry is parameterized by numerology constants passed via NUM.
-*/
-
-export function renderHelix(ctx, { width, height, palette, NUM }) {
-  // Clear background with calm tone
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  // Draw layers back to front for depth without motion
-    1) Vesica field – intersecting circles grid
-    2) Tree-of-Life – ten sephirot with twenty-two paths
-    3) Fibonacci curve – static logarithmic spiral polyline
-    4) Double-helix lattice – two sine strands with crossbars
-
-  All geometry is static; no animation, network, or external deps.
-*/
-
-export function renderHelix(ctx, { width, height, palette, NUM }) {
-  // clear background with calm color
-  Layers:
-    1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 nodes, 22 paths)
-    3) Fibonacci curve (logarithmic spiral polyline)
-    4) Double-helix lattice (two phase-shifted sine strands)
-
-  No animation or network calls. Calm palette and fixed geometry
-  promote sensory safety. All geometry sizes use numerology constants.
+  Geometry uses numerology constants passed via NUM.
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
-}
-
-// L1 — Vesica field: intersecting circle grid
-// --- Layer 1: Vesica field ---
-function drawVesica(ctx, w, h, color, NUM) {
-  const cols = NUM.NINE; // gentle grid
-  const rows = NUM.SEVEN;
-  const stepX = w / cols;
-  const stepY = h / rows;
-  const r = Math.min(stepX, stepY) / 2;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  const r = Math.min(w, h) / NUM.THREE; // base radius from numerology
-  const step = r;
-  for (let y = -r; y <= h + r; y += step) {
-    for (let x = -r; x <= w + r; x += step) {
-// Layer 1 — Vesica field
-function drawVesica(ctx, w, h, color, NUM) {
-  // gentle grid of overlapping circles; no motion
-  const r = Math.min(w, h) / NUM.THREE;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h; y += r) {
-    for (let x = r; x < w; x += r) {
-    4) Double-helix lattice
-  Pure functions, no animation, offline-only.
-*/
-
-// Entry point: orchestrates all layers
-export function renderHelix(ctx, { width, height, palette, NUM }) {
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
   drawVesica(ctx, width, height, palette.layers[0], NUM);
   drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
   drawFibonacci(ctx, width, height, palette.layers[3], NUM);
@@ -86,93 +23,38 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
 }
 
 // --- Layer 1: Vesica field ---
-// Gentle circle grid; no overlaps beyond 144 iterations
 function drawVesica(ctx, w, h, color, NUM) {
-  const cols = NUM.NINE; // 9 columns
-  const rows = NUM.SEVEN; // 7 rows
-  const r = Math.min(w / cols, h / rows) / 2;
+  // grid of overlapping circles; calm symmetry, no motion
+  const cols = NUM.NINE;
+  const rows = NUM.SEVEN;
+  const stepX = w / cols;
+  const stepY = h / rows;
+  const r = Math.min(stepX, stepY) / 2;
+
   ctx.strokeStyle = color;
   ctx.lineWidth = 1;
+
   for (let c = 0; c < cols; c++) {
     for (let rIdx = 0; rIdx < rows; rIdx++) {
-      const x = (c + 0.5) * (w / cols);
-      const y = (rIdx + 0.5) * (h / rows);
-      ctx.beginPath();
-      ctx.arc(x, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + r, y, r, 0, Math.PI * 2);
-  for (let rIdx = 0; rIdx < rows; rIdx++) {
-    for (let c = 0; c < cols; c++) {
       const cx = c * stepX + stepX / 2;
       const cy = rIdx * stepY + stepY / 2;
-      circle(ctx, cx - r / 2, cy, r);
+      ctx.beginPath();
+      ctx.arc(cx - r / 2, cy, r, 0, Math.PI * 2);
       ctx.stroke();
-      circle(ctx, cx + r / 2, cy, r);
-      ctx.arc(x + r / NUM.THREE, y, r, 0, Math.PI * 2);
+      ctx.beginPath();
+      ctx.arc(cx + r / 2, cy, r, 0, Math.PI * 2);
       ctx.stroke();
     }
   }
 }
 
-// L2 — Tree-of-Life scaffold (10 nodes, 22 paths)
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  const cx = w / 2;
-  const xo = w / NUM.NINE;
-  const ys = h / NUM.NINE;
-  const nodes = [
-    [cx, ys * 0.5],
-    [cx + xo, ys * 1.5],
-    [cx - xo, ys * 1.5],
-    [cx - xo * 1.2, ys * 3],
-    [cx + xo * 1.2, ys * 3],
-    [cx, ys * 4.5],
-    [cx - xo, ys * 6],
-    [cx + xo, ys * 6],
-    [cx, ys * 7.5],
-    [cx, ys * 9],
 // --- Layer 2: Tree-of-Life scaffold ---
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  const xo = w / 6;
-  const yo = h / 10;
-  const nodes = [
-    [w / 2, yo],
-    [w / 2 + xo, yo * 2],
-    [w / 2 - xo, yo * 2],
-    [w / 2 - xo * 1.5, yo * 4],
-    [w / 2 + xo * 1.5, yo * 4],
-    [w / 2, yo * 5],
-    [w / 2 - xo, yo * 6.5],
-    [w / 2 + xo, yo * 6.5],
-    [w / 2, yo * 8],
-    [w / 2, yo * 9]
-// Layer 2 — Tree-of-Life scaffold
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  const ys = h / NUM.TWENTYTWO; // vertical spacing based on 22 paths
-  const nodes = [
-    [w / 2, ys * 1],
-    [w * 0.65, ys * 3],
-    [w * 0.35, ys * 3],
-    [w * 0.35, ys * 6],
-    [w * 0.65, ys * 6],
-    [w / 2, ys * 8],
-    [w * 0.35, ys * 12],
-    [w * 0.65, ys * 12],
-    [w / 2, ys * 16],
-    [w / 2, ys * 20]
-  ];
-  const paths = [
-    [0,1],[0,2],[0,5],
-    [1,3],[1,5],[1,6],
-    [2,4],[2,5],[2,7],
-    [3,4],[3,5],[3,6],
-    [4,5],[4,7],
-// --- Layer 2: Tree-of-Life scaffold ---
-// 10 nodes (sephirot) and 22 connecting paths
 function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, NUM) {
   const cx = w / 2;
   const stepX = w / NUM.NINE;
   const stepY = h / NUM.NINE;
+
+  // node positions derived from traditional layout
   const nodes = [
     [cx, stepY * 0.5],
     [cx + stepX, stepY * 1.5],
@@ -185,6 +67,8 @@ function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, NUM) {
     [cx, stepY * 7.5],
     [cx, stepY * 9]
   ];
+
+  // 22 connecting paths
   const paths = [
     [0,1],[0,2],[0,5],
     [1,2],[1,3],[1,5],[1,6],
@@ -195,11 +79,8 @@ function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, NUM) {
     [6,7],[6,8],
     [7,8],
     [8,9]
-  ]; // NUM.TWENTYTWO paths
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 2;
-  paths.forEach(([a, b]) => {
   ];
+
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 2;
   for (const [a, b] of paths) {
@@ -210,61 +91,25 @@ function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, NUM) {
     ctx.lineTo(bx, by);
     ctx.stroke();
   }
+
   ctx.fillStyle = nodeColor;
-  const r = NUM.SEVEN; // small node size
+  const r = NUM.SEVEN; // small steady nodes
   for (const [x, y] of nodes) {
     ctx.beginPath();
     ctx.arc(x, y, r, 0, Math.PI * 2);
-  for (const [x, y] of nodes) {
-    ctx.beginPath();
-    ctx.arc(x, y, NUM.SEVEN, 0, Math.PI * 2);
     ctx.fill();
   }
 }
 
-// L3 — Fibonacci curve: static logarithmic spiral
-function drawFibonacci(ctx, w, h, color, NUM) {
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  paths.forEach(([a,b]) => {
-    ctx.beginPath();
-    ctx.moveTo(...nodes[a]);
-    ctx.lineTo(...nodes[b]);
-    ctx.stroke();
-  });
-  ctx.fillStyle = nodeColor;
-  const r = NUM.NINE / 2;
-  nodes.forEach(([x,y]) => {
-    circle(ctx, x, y, r);
-  });
-  ctx.fillStyle = nodeColor;
-  const r = NUM.SEVEN; // small steady nodes
-  nodes.forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.fill();
-  });
-}
-
 // --- Layer 3: Fibonacci curve ---
-function drawFibonacci(ctx, w, h, color, NUM) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = NUM.THREE; // three quarter-turns
-  const steps = NUM.NINETYNINE;
-// Layer 3 — Fibonacci curve
 function drawFibonacci(ctx, w, h, color, NUM) {
   const phi = (1 + Math.sqrt(5)) / 2;
   const turns = NUM.THREE; // three quarter-turns
   const steps = NUM.NINETYNINE; // smoothness
-// --- Layer 3: Fibonacci curve ---
-// Log spiral approximation using polyline
-function drawFibonacci(ctx, w, h, color, NUM) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = NUM.THREE; // three quarter-turns
-  const steps = NUM.NINETYNINE; // resolution
   const scale = Math.min(w, h) / NUM.ELEVEN;
   const cx = w * 0.2;
   const cy = h * 0.8;
+
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
   ctx.beginPath();
@@ -278,89 +123,37 @@ function drawFibonacci(ctx, w, h, color, NUM) {
   ctx.stroke();
 }
 
-// L4 — Double-helix lattice: two phase-shifted sine curves
-function drawHelix(ctx, w, h, colorA, colorB, NUM) {
-  const amp = h / NUM.NINE; // gentle wave
-  const segments = NUM.ONEFORTYFOUR; // resolution
-  const step = w / segments;
-  const phase = Math.PI; // second strand offset
-
 // --- Layer 4: Double-helix lattice ---
-// Two sine strands with 33 crossbars
 function drawHelix(ctx, w, h, colorA, colorB, NUM) {
-  const amplitude = h / NUM.NINE;
-  const amp = h / NUM.NINE;
-  const segments = NUM.NINETYNINE;
-  const step = w / segments;
-  const phase = Math.PI;
-  const strand = (offset, color) => {
+  const segments = NUM.ONEFORTYFOUR; // smooth strands
+  const amp = h / NUM.NINE; // gentle wave
+  const mid = h / 2;
+
+  const strand = (phase, color) => {
     ctx.strokeStyle = color;
     ctx.beginPath();
     for (let i = 0; i <= segments; i++) {
-      const x = i * step;
-      const y = h / 2 + amp * Math.sin((i / NUM.THREE) * Math.PI * 2 + offset);
-      const y = h/2 + amp * Math.sin((i / NUM.THREE) * Math.PI * 2 + offset);
+      const t = (i / segments) * Math.PI * NUM.THREE + phase;
+      const x = (i / segments) * w;
+      const y = mid + Math.sin(t) * amp;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
     }
     ctx.stroke();
   };
 
   strand(0, colorA);
-  strand(phase, colorB);
+  strand(Math.PI, colorB);
 
   // crossbars every 11th segment for stability
   ctx.strokeStyle = colorB;
   for (let i = 0; i <= segments; i += NUM.ELEVEN) {
-    const x = i * step;
-    const y1 = h / 2 + amp * Math.sin((i / NUM.THREE) * Math.PI * 2);
-    const y2 = h / 2 + amp * Math.sin((i / NUM.THREE) * Math.PI * 2 + phase);
-  strand(0, colorA);
-  strand(phase, colorB);
-  ctx.strokeStyle = colorB;
-  for (let i = 0; i <= segments; i += NUM.ELEVEN) {
-    const x = i * step;
-    const y1 = h/2 + amplitude * Math.sin((i / NUM.THREE) * Math.PI * 2);
-    const y2 = h/2 + amplitude * Math.sin((i / NUM.THREE) * Math.PI * 2 + phase);
-// Layer 4 — Double-helix lattice
-function drawHelix(ctx, w, h, colorA, colorB, NUM) {
-  const segments = NUM.ONEFORTYFOUR; // 144 segments for smooth strands
-  const amp = h / NUM.NINE; // gentle wave height
-  const mid = h / 2;
-  ctx.strokeStyle = colorA;
-  ctx.beginPath();
-  for (let i = 0; i <= segments; i++) {
     const t = (i / segments) * Math.PI * NUM.THREE;
     const x = (i / segments) * w;
-    const y = mid + Math.sin(t) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-  ctx.strokeStyle = colorB;
-  ctx.beginPath();
-  for (let i = 0; i <= segments; i++) {
-    const t = (i / segments) * Math.PI * NUM.THREE + Math.PI;
-    const x = (i / segments) * w;
-    const y = mid + Math.sin(t) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-  // crossbars every eleventh segment for stability
-  for (let j = 0; j <= segments; j += NUM.ELEVEN) {
-    const t = (j / segments) * Math.PI * NUM.THREE;
-    const x = (j / segments) * w;
     const y1 = mid + Math.sin(t) * amp;
     const y2 = mid + Math.sin(t + Math.PI) * amp;
-    ctx.strokeStyle = colorA;
-    const y1 = h/2 + amp * Math.sin((i / NUM.THREE) * Math.PI * 2);
-    const y2 = h/2 + amp * Math.sin((i / NUM.THREE) * Math.PI * 2 + phase);
     ctx.beginPath();
     ctx.moveTo(x, y1);
     ctx.lineTo(x, y2);
     ctx.stroke();
   }
-}
-
-function circle(ctx, x, y, r) {
-  ctx.beginPath();
-  ctx.arc(x, y, r, 0, Math.PI * 2);
 }


### PR DESCRIPTION
## Summary
- Rebuild helix-renderer.mjs with pure functions for Vesica, Tree-of-Life, Fibonacci, and double-helix layers
- Deduplicate README_RENDERER and document offline ND-safe renderer usage and palette

## Testing
- `node --check js/helix-renderer.mjs`
- `node -e "import('./js/helix-renderer.mjs').then(m=>console.log('exports', Object.keys(m)))"`


------
https://chatgpt.com/codex/tasks/task_e_68c4fc777da0832882cb7f7766bc66b1