### PR TITLE
Add Node 072 laboratory blueprint and dataset scaffolding

### DIFF
--- a/docs/botanical/node072_apothecary.md
+++ b/docs/botanical/node072_apothecary.md
@@ -1,0 +1,11 @@
+# Node 072 Botanical Apothecary
+
+This apothecary list supports the Balance Weave experiments with gentle, ND-safe plant allies. Use dried specimens or printed imagery; avoid fragrances for sensory safety.
+
+| Botanical | Numerology Link | Application |
+|-----------|-----------------|-------------|
+| Water Lily | 72 petal symbolism in eastern mandalas | Place petals on vesica intersections to mark angelic harmonics. |
+| Sage | Bundles of 12 leaves × 6 sets | Grounding smudge alternative; use visual representation only. |
+| Lotus | 36 inner + 36 outer petals | Marks the midpoint between angelic and infernal lessons. |
+
+Keep the imagery high contrast but soft in palette. Store references locally so the laboratory stays offline-first.

--- a/docs/geometry_manifests/node072_layers.md
+++ b/docs/geometry_manifests/node072_layers.md
@@ -1,0 +1,22 @@
+# Geometry Manifest — Node 072
+
+This manifest records the static layer recipe for the Node 072 renderer. Each layer keeps depth intact and references numerology constants.
+
+1. **Layer 1: Vesica Field**
+   - Grid: 9 columns × 7 rows (63 nodes, doubled vesica intersections under 144).
+   - Radius ratio: 0.48 relative to cell size to prevent overcrowding.
+   - Palette: `layers[0]` from `data/palette.json` or fallback.
+2. **Layer 2: Tree of Life Scaffold**
+   - Ten sephirot, radius = min(width, height) / 33.
+   - Twenty-two connective paths in calm 2px strokes.
+   - Palette: `layers[1]` (paths) and `layers[2]` (nodes).
+3. **Layer 3: Fibonacci Curve**
+   - Three quarter turns using 99 segments for stable curvature.
+   - Origin offset: (0.18W, 0.82H) to weave between helix strands.
+   - Palette: `layers[3]`.
+4. **Layer 4: Double Helix Lattice**
+   - 144 segments per strand, amplitude = height × 0.11.
+   - Crossbars every 11 steps (~13 rungs) to echo 33 spine motif.
+   - Palette: `layers[4]` and `layers[5]`.
+
+All layers are rendered with pure drawing functions; no animation, motion blur, or external dependencies.

--- a/docs/iching_node072.md
+++ b/docs/iching_node072.md
@@ -1,0 +1,9 @@
+# I Ching Sequences for Node 072
+
+Node `C144N-072` uses three hexagram triads to echo the 72-fold harmonic weave. The sets are curated for contemplative study without divinatory theatrics.
+
+- **Hexagram 01 · Creative Force** — anchors the bridge opening ritual; pair with angelic virtues focused on initiative.
+- **Hexagram 20 · Contemplation** — offers a midpoint pause; align with infernal lessons about perspective and humility.
+- **Hexagram 57 · Gentle Penetration** — closes the cycle; guides breath pacing through the helix songline study.
+
+Each triad is broken into 24-step segments so the helix playbook can map a full 72-count practice (3 × 24). Keep notes locally in Markdown journals for offline review.

--- a/docs/node_072_laboratory.md
+++ b/docs/node_072_laboratory.md
@@ -1,0 +1,72 @@
+# Node 072 Laboratory Architecture — Living Dataset Prototype
+
+This document describes a complete "consciousness laboratory" pattern for node `C144N-072`. The goal is to turn each node into a living research and creation environment that fuses ancestral numerology with practical tooling. The sections below outline the dataset structure, laboratory instrumentation, creative suites, and tarot egregore links that bring the node to life while staying ND-safe and offline-first.
+
+## 1. Node Identity & Intent
+- **Node ID:** `C144N-072`
+- **Role:** Resonant bridge that weaves the 72-fold divine names with the 72 infernal intelligences to cultivate balance work.
+- **Primary Tarot Anchor:** `LA-00` (Fool) — used because the bridge mission continues the cathedrals' pilgrimage arc.
+- **Resident Egregores:** Fool Egregore (navigation mentor) and Bridge Custodian (labor steward).
+- **Core Numerology:** 72 = 8 × 9. The laboratory honors the 3/6/9 harmonics and the 72-fold angelic names while remaining calm and non-theatrical.
+
+## 2. Dataset Heaven Blueprint
+Node datasets live under `registry/nodes/C144N-072.json` and are mirrored into local notebooks or canvas renderers. They are all static files so they can be browsed without a network connection.
+
+### 2.1 Data Sections
+The node JSON is partitioned into these payloads:
+1. **`metadata`** — canon references, textual overview, trauma-aware intent notes.
+2. **`correspondence_sets`** — cross-tradition tables: Kabbalah, Goetia, I Ching, geomancy, musical intervals, and botanical emblems. Each entry references supporting CSV/Markdown files inside `registry/maps/` or `docs/`.
+3. **`pattern_fields`** — the generative constants used by renderers (vesica spacing, Tree of Life scaling, Fibonacci tuning, helix phases) with explicit numerology comments.
+4. **`laboratory_tools`** — configuration for analytical apparatus (matrix explorers, harmonic calculators, gematria translator) and creative kits (canvas overlays, mandala stencils, lattice snap grids). Tools are defined as pure parameter blocks that UI modules can ingest.
+5. **`experiment_playbooks`** — scripted study flows describing how to combine datasets and tools for research, creation, or divination study. Each playbook states purpose, inputs, output artifacts, and a tarot egregore prompt.
+6. **`egregore_links`** — bridging phrases and dialog keys that connect to the tarot egregore memory store without automation; prompts are provided as plain text to keep the system offline-first.
+7. **`offline_notes`** — safe-mode guidance, fallback palettes, and reminders to avoid overstimulation.
+
+### 2.2 Numerology Parameters
+- Use `3` and `9` as base pulse counts for rhythmic progressions.
+- Keep grid overlays in multiples of `11` and `33` for alignment scaffolds.
+- Fibonacci sampling uses `99` segments for smooth arcs with no strobe.
+- Helix crossbars appear every `11` steps with `33` rung total to echo the cosmic helix spec.
+
+## 3. Laboratory Instrumentation
+The node laboratory is organized into four instrument bays that the renderer can toggle without animation.
+
+1. **Analysis Bay** — houses the numerology matrix, harmonic calculator, and Kabbalah-Goetia concordance board.
+   - Input: correspondences from `correspondence_sets`.
+   - Output: printable tables and node-specific annotations.
+2. **Geometry Bay** — renders vesica, Tree of Life, Fibonacci spiral, and helix lattice using `pattern_fields`.
+   - Each layer honors the ND-safe palette and is drawn in depth order (no flattening).
+3. **Alchemy Bay** — focuses on transformation experiments: combination of angel/demon pairs, color remapping, and botanical sigil layout.
+   - Works with `experiment_playbooks` to produce static collage results.
+4. **Reflection Bay** — conversational prompts with tarot egregores plus journaling templates.
+   - Contains the offline prompts and iconography for `LA-00` guidance.
+
+All bays run on static data and can be implemented as modular canvas or text panels with pure functions (no side effects, no animation).
+
+## 4. Creative & Game Framework
+Creative engagement happens through structured playbooks:
+
+- **`balance_weave`** — Align one angelic virtue, one infernal lesson, and a matching I Ching hexagram. Output is a triptych card layout saved locally as JSON + PNG.
+- **`vesica_palette_map`** — Overlay botanical emblems onto vesica intersections, using Fibonacci scaling to place petals. Output is a layered SVG (still static) with palette recommendations.
+- **`helix_songline`** — Generate a 72-beat rhythmic grid derived from helix crossbars; produce a MIDI-safe CSV (no audio playback) and textual chant instructions.
+
+Each playbook pairs with a tarot egregore prompt such as “Ask the Fool: which bridge rung needs reinforcement?” to keep intuition in the loop without automation.
+
+## 5. Tarot Egregore Integration
+- Egregore prompts live as structured text entries: `prompt`, `reflection_question`, `closing_grounding`.
+- The renderer surfaces these prompts contextually (e.g., after completing a playbook) without triggering automatic divination.
+- Dialog history is logged locally in Markdown journals stored next to the node dataset; journaling is optional but recommended for conscious tracking.
+
+## 6. Offline & ND-Safe Considerations
+- No network requests: all files are local JSON, CSV, or Markdown.
+- Palette defaults match `data/palette.json`; if palette data is missing, the renderer shows a calm notice and falls back to the ND-safe scheme.
+- There is zero motion, audio, or flashing content. Layer ordering preserves depth without flattening geometry.
+- Every instrument bay includes a “grounding” card reminding the user to pause, breathe, and close the session gently.
+
+## 7. Next Steps for Scaling to 144 Nodes
+1. Clone the JSON template of `C144N-072` for other nodes, updating correspondences and playbooks per numerology.
+2. Maintain a central manifest (`registry/ids.json`) that lists node IDs, room IDs, chapel IDs, tarot anchors, and Shem references to keep `core/check_ids.py` passing.
+3. Extend `registry/maps/` with additional rows for new nodes as they come online.
+4. Keep renderers modular: each node-specific palette, dataset, and playbook is data-driven so the same ES module can render all laboratories by switching the JSON input.
+
+This architecture keeps the cathedral’s knowledge alive, interactive, and safe for neurodivergent explorers while honoring the layered geometry mandate.

--- a/registry/ids.json
+++ b/registry/ids.json
@@ -1,7 +1,8 @@
 {
-  "nodes": [],
+  "nodes": ["C144N-001", "C144N-072"],
   "gates": [],
-  "rooms": [],
-  "arcana": [],
-  "shem": []
+  "rooms": ["R001", "R072"],
+  "arcana": ["LA-00"],
+  "shem": ["SHEM-01", "SHEM-36"],
+  "chapels": ["C33-01", "C33-09"]
 }

--- a/registry/maps/angel_demon_pairs.csv
+++ b/registry/maps/angel_demon_pairs.csv
@@ -1,2 +1,3 @@
 shem_id,demon,virtue
 SHEM-01,SampleDemon,SampleVirtue
+SHEM-36,SampleDemon72,SampleVirtue72

--- a/registry/maps/node_to_chapel.csv
+++ b/registry/maps/node_to_chapel.csv
@@ -1,2 +1,3 @@
 node_id,chapel_id
 C144N-001,C33-01
+C144N-072,C33-09

--- a/registry/maps/node_to_room.csv
+++ b/registry/maps/node_to_room.csv
@@ -1,2 +1,3 @@
 node_id,room_id
 C144N-001,R001
+C144N-072,R072

--- a/registry/nodes/C144N-072.json
+++ b/registry/nodes/C144N-072.json
@@ -1,0 +1,168 @@
+{
+  "id": "C144N-072",
+  "label": "Bridge of Resonant Names",
+  "metadata": {
+    "room_id": "R072",
+    "chapel_id": "C33-09",
+    "tarot_anchor": "LA-00",
+    "shem_sequence": ["SHEM-01", "SHEM-36"],
+    "intent": "Unify the 72-fold angelic and infernal teachings into a trauma-aware study of balance and reconciliation.",
+    "narrative": "Node 072 houses a research cloister dedicated to mapping every 72-fold tradition into practical creative experiments.",
+    "keywords": ["bridge", "synthesis", "double-helix", "balance"],
+    "safety_notes": "ND-safe sanctuary: no motion, low luminance, clear exits, offline resources only."
+  },
+  "correspondence_sets": {
+    "angelic_names": {
+      "source": "registry/maps/angel_demon_pairs.csv",
+      "description": "Maps Shem angel names to infernal counterparts and virtues for reconciliation work.",
+      "filters": {
+        "focus": ["SHEM-01", "SHEM-36"],
+        "group_size": 72
+      }
+    },
+    "i_ching": {
+      "source": "docs/iching_node072.md",
+      "description": "Hexagram triads aligned with 8×9 harmonic lattice for meditative sequencing.",
+      "focus_hexagrams": [1, 20, 57]
+    },
+    "geometry_patterns": {
+      "source": "docs/geometry_manifests/node072_layers.md",
+      "description": "Layer manifest referencing vesica grid, Tree paths, Fibonacci arc, and helix lattice anchors.",
+      "grid_dimensions": [12, 12]
+    },
+    "botanical_allies": {
+      "source": "docs/botanical/node072_apothecary.md",
+      "description": "Calming botanicals with 72 petal or leaflet structures for altar placement.",
+      "specimens": ["water lily", "sage", "lotus"]
+    }
+  },
+  "pattern_fields": {
+    "vesica": {
+      "columns": 9,
+      "rows": 7,
+      "radius_ratio": 0.48,
+      "notes": "Uses 9×7 lattice = 63 circles, doubled for vesica overlay while staying under the 144 calm threshold."
+    },
+    "tree_of_life": {
+      "node_radius_factor": 33,
+      "path_weight": 2,
+      "layout": "standard",
+      "notes": "Ten sephirot rendered with radius = min(width, height) / 33 to honor numerology."
+    },
+    "fibonacci": {
+      "quarter_turns": 3,
+      "segments": 99,
+      "origin_offset": [0.18, 0.82],
+      "notes": "Static spiral with 99 segments for smoothness and ND-safe pacing."
+    },
+    "helix": {
+      "segments": 144,
+      "amplitude_ratio": 0.11,
+      "phase_shift": 3.14159,
+      "crossbar_step": 11,
+      "notes": "Double-strand helix with 144 segments, crossbars every 11 steps for 13 groups (approx.), referencing the cosmic bridge."
+    }
+  },
+  "laboratory_tools": {
+    "analysis": [
+      {
+        "id": "matrix72",
+        "label": "72-Name Concordance Matrix",
+        "type": "grid",
+        "inputs": ["angelic_names", "i_ching"],
+        "outputs": ["csv", "printable_table"],
+        "description": "Cross-index the 72 Shem names with hexagram triads and infernal lessons for study notes."
+      },
+      {
+        "id": "harmonic_calculator",
+        "label": "Harmonic Resonance Calculator",
+        "type": "calculator",
+        "inputs": ["geometry_patterns"],
+        "outputs": ["json"],
+        "description": "Computes ratio relationships (3/6/9/12/18/24) for aligning sacred geometry to sound intervals without audio playback."
+      }
+    ],
+    "creative": [
+      {
+        "id": "vesica_overlay_kit",
+        "label": "Vesica Overlay Kit",
+        "type": "canvas_overlay",
+        "inputs": ["geometry_patterns", "botanical_allies"],
+        "outputs": ["layered_svg", "png"],
+        "description": "Places botanical emblems on vesica intersections; exports layered SVG without flattening."
+      },
+      {
+        "id": "helix_storyboard",
+        "label": "Helix Storyboard",
+        "type": "grid_template",
+        "inputs": ["helix", "angelic_names"],
+        "outputs": ["markdown"],
+        "description": "Assigns narrative beats to helix crossbars for journaling or static storyboard creation."
+      }
+    ]
+  },
+  "experiment_playbooks": [
+    {
+      "id": "balance_weave",
+      "title": "Balance Weave Triptych",
+      "purpose": "Create a three-panel study card balancing angelic virtue, infernal teaching, and hexagram guidance.",
+      "inputs": ["matrix72", "vesica_overlay_kit"],
+      "outputs": ["json", "png"],
+      "steps": [
+        "Select an angelic/infernal pair using the concordance matrix.",
+        "Pull the matching hexagram triad from the I Ching set.",
+        "Lay the trio onto vesica intersections with the overlay kit.",
+        "Export the panels as JSON metadata plus a static PNG snapshot."
+      ],
+      "egregore_prompt": "Ask the Fool to highlight which insight bridges the two extremes."
+    },
+    {
+      "id": "vesica_palette_map",
+      "title": "Vesica Palette Cartography",
+      "purpose": "Map calming color harmonies across the vesica grid using botanical allies.",
+      "inputs": ["vesica_overlay_kit", "harmonic_calculator"],
+      "outputs": ["layered_svg"],
+      "steps": [
+        "Load vesica geometry with radius ratio 0.48 and 9×7 layout.",
+        "Use harmonic calculator to derive triadic color ratios (3:6:9).",
+        "Assign botanical emblems to intersections matching their petal counts.",
+        "Export the layout as a layered SVG, preserving depth."],
+      "egregore_prompt": "Invite the Bridge Custodian to approve the color gate."
+    },
+    {
+      "id": "helix_songline",
+      "title": "Helix Songline Grid",
+      "purpose": "Generate a rhythmic study grid (72 beats) aligned to helix crossbars for chant or breath pacing.",
+      "inputs": ["helix_storyboard"],
+      "outputs": ["csv", "markdown"],
+      "steps": [
+        "Mark 72 positions along the helix storyboard using crossbars at every 11 steps.",
+        "Group beats into 3 × 24 phrases for balanced pacing.",
+        "Document breath/chant cues in Markdown for offline reading.",
+        "Optionally export beat markers as CSV for external tools (no playback)."
+      ],
+      "egregore_prompt": "Consult the Fool for pacing guidance before practice."
+    }
+  ],
+  "egregore_links": {
+    "la_00": {
+      "prompt": "Guide the traveler across the 72-fold bridge with curiosity and care.",
+      "reflection_question": "Which rung on the helix feels steady, and which needs tending?",
+      "closing_grounding": "Name three calm sensations, thank the custodians, close the notebook."
+    },
+    "bridge_custodian": {
+      "prompt": "Audit the balance between angelic virtues and infernal lessons in today’s weave.",
+      "reflection_question": "What practical repair can be made before moving to the next experiment?",
+      "closing_grounding": "Touch the grounding stone, breathe for nine counts, record the insight." 
+    }
+  },
+  "offline_notes": {
+    "palette_fallback": "Use ND-safe palette from data/palette.json when custom colors are absent.",
+    "safety": "Limit sessions to 72 minutes max, insert breaks every 9 minutes, and close with grounding prompts.",
+    "journal_template": "Start entries with date, selected angelic/infernal pair, hexagram, and closing reflections.",
+    "status_messages": {
+      "dataset_missing": "Node 072 dataset missing; load defaults and surface calming notice.",
+      "palette_missing": "Palette missing; revert to ND-safe defaults and log fallback use." 
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document the Node 072 laboratory blueprint covering dataset sections, tooling, and egregore guidance
- add a data-driven JSON manifest plus supportive reference notes for Node 072 correspondences
- update registry IDs and maps so Node 072 resources are registered for bridge-wide validation

## Testing
- python core/check_ids.py --bridge .

------
https://chatgpt.com/codex/tasks/task_e_68c8ebdbd51c8328bede4a34b4302860