### PR TITLE
Add inline fallback notice and offline-safe palette handling

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -16,7 +16,7 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
    - Tree-of-Life nodes and paths
    - Fibonacci curve
    - Static double-helix lattice
-4. If `data/palette.json` is absent, the header reports the fallback and calm defaults are used.
+4. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
 
 ## Palette
 `data/palette.json` structure:
@@ -30,6 +30,10 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
 ```
 
 Edit the file to customize colors, or delete it to exercise the fallback notice.
+
+When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline
+notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a local
+server temporarily and open the same files there.
 
 ## ND-safe choices
 - No animation, autoplay, or network requests.

--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
     const ctx = canvas.getContext("2d");
 
     async function loadJSON(path) {
+      // Offline assurance: avoid fetch when opened via file:// to honor the no-network brief.
+      if (window.location.protocol === "file:") {
+        return null;
+      }
       try {
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
@@ -52,13 +56,19 @@
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const notices = [];
+    if (palette) {
+      elStatus.textContent = "Palette loaded.";
+    } else {
+      elStatus.textContent = "Palette missing; using safe fallback.";
+      notices.push("Palette JSON not available; calm defaults engaged.");
+    }
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a calm inline notice on the canvas whenever palette.json is missing while still rendering all four layers
- guard palette loading when opened via the file protocol to honor the no-network requirement
- document the inline notice and the palette loading behavior in the renderer README

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c94e94b27c83289a09199fbfdfb706