### PR TITLE
Enforce WEBP hero art fallback and guard PNG assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # LFS filters removed; file intentionally left without filter entries.
 # (intentionally left blank; binary assets are not tracked via Git LFS)
+*.png -filter -diff -merge

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Thumbs.db
 __pycache__/
 *.pyc
+# Guarded PNG masters (kept offline per anti-resurrection brief)
+assets/art/black-madonna-altar-1600.png

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,9 +3,13 @@
 Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
 
 ## Files
-- `index.html` – entry document that sets up the canvas and loads the renderer module.
+- `index.html` – entry document that sets up the canvases, loads the renderer module, paints the octagram fallback, and mounts optional hero art.
 - `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
+- `assets/js/first-paint-octagram.js` – chapel-safe first paint to ensure a calm field if hero art is offline.
+- `assets/js/art-loader.js` – manifest-driven WEBP loader with ND-safe fallbacks.
+- `assets/art/manifest.json` – declares the live WEBP hero asset (relative paths keep it offline-friendly).
 - `data/palette.json` – optional palette override; missing file triggers a safe fallback notice.
+- `scripts/verify-absent.mjs` – guard executed before builds to ensure forbidden PNG masters stay absent.
 - `README_RENDERER.md` – this usage guide.
 
 ## Usage
@@ -16,7 +20,9 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
    - Tree-of-Life nodes and paths
    - Fibonacci curve
    - Static double-helix lattice
-4. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
+4. The octagram canvas (`#opus`) paints immediately, so visitors perceive the chapel geometry even if hero art or network requests stall.
+5. If `assets/art/black-madonna-altar-1600.webp` is present, the manifest loader displays it; otherwise `#hero-art` shows a calm fallback note while the octagram remains visible.
+6. The header status line reports palette or hero-art fallbacks as they happen, and `renderHelix` writes the same notes onto the geometry canvas.
 
 ## Palette
 `data/palette.json` structure:
@@ -31,12 +37,17 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
 
 Edit the file to customize colors, or delete it to exercise the fallback notice.
 
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline
-notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a local
-server temporarily and open the same files there.
+When launched via `file://`, browsers often block local fetches; the renderer therefore skips the palette request and displays the inline notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a temporary local server.
+
+## Guards and health checks
+- `.gitattributes` disables LFS filters for PNG to prevent accidental smudging.
+- `.gitignore` blocks `assets/art/black-madonna-altar-1600.png` from returning.
+- `scripts/verify-absent.mjs` exits non-zero if the forbidden PNG reappears. It runs via the `prebuild` npm script and can be invoked manually with `node scripts/verify-absent.mjs`.
+- `core/health-check.html` offers an offline diagnostics page to confirm build timestamp and whether Netlify gating is active.
 
 ## ND-safe choices
-- No animation, autoplay, or network requests.
+- No animation, autoplay, or network dependencies beyond optional manifest fetches (which gracefully fail when offline).
 - Calm contrast, layered order, and generous spacing for readability.
 - Layer hierarchy (Vesica → Tree → Fibonacci → Helix) keeps geometry multi-layered rather than flattened.
 - Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144` to honor the cosmology brief.
+- Octagram fallback and WEBP-only manifest prevent PNG resurrection while keeping the public shell beautiful.

--- a/assets/art/manifest.json
+++ b/assets/art/manifest.json
@@ -1,0 +1,9 @@
+{
+  "_about": "WEBP-only live art",
+  "policy": { "formats": ["webp"], "nd_safe": true },
+  "hero": {
+    "id": "black-madonna-altar",
+    "src": "./black-madonna-altar-1600.webp",
+    "alt": "Black Madonna altar in obsidian and opal tones"
+  }
+}

--- a/assets/js/art-loader.js
+++ b/assets/js/art-loader.js
@@ -1,0 +1,141 @@
+/*
+  art-loader.js
+  Fetches WEBP art metadata and mounts a static image into the page.
+  ND-safe: eager loading without motion, graceful fallback when assets are offline.
+*/
+
+export async function mountArt(options = {}) {
+  const opts = {
+    manifestPath: "./assets/art/manifest.json",
+    targetId: "hero-art",
+    statusElement: null,
+    onFallback: null,
+    ...options
+  };
+
+  const mountPoint = document.getElementById(opts.targetId);
+  if (!mountPoint) {
+    const msg = "Hero art mount missing; octagram fallback only.";
+    triggerFallback(opts, msg);
+    return null;
+  }
+
+  const manifestResult = await fetchManifest(opts.manifestPath);
+  if (!manifestResult.manifest) {
+    mountPoint.textContent = manifestResult.message;
+    triggerFallback(opts, manifestResult.message);
+    return null;
+  }
+
+  const hero = normalizeHero(manifestResult.manifest.hero, manifestResult.baseUrl);
+  if (!hero) {
+    const msg = "Manifest missing hero art; octagram fallback active.";
+    mountPoint.textContent = msg;
+    triggerFallback(opts, msg);
+    return null;
+  }
+
+  const img = buildHeroImage(hero);
+  mountPoint.innerHTML = "";
+  mountPoint.appendChild(img);
+  updateStatus(opts.statusElement, "Loading hero art (WEBP)...");
+
+  const onLoad = () => {
+    updateStatus(opts.statusElement, "Hero art mounted (WEBP).");
+  };
+  const onError = () => {
+    const msg = "Hero art resource missing; octagram fallback active.";
+    mountPoint.textContent = msg;
+    triggerFallback(opts, msg);
+  };
+
+  img.addEventListener("load", onLoad, { once: true });
+  img.addEventListener("error", onError, { once: true });
+
+  if (img.complete) {
+    if (img.naturalWidth > 0) {
+      onLoad();
+    } else {
+      onError();
+    }
+  }
+
+  return hero;
+}
+
+async function fetchManifest(path) {
+  const baseUrl = resolveBaseUrl(path);
+  try {
+    const response = await fetch(baseUrl.href, { cache: "no-store" });
+    if (!response.ok) {
+      return { manifest: null, baseUrl, message: "Manifest fetch failed; octagram fallback ready." };
+    }
+    const data = await response.json();
+    return { manifest: data, baseUrl, message: "Manifest loaded." };
+  } catch (error) {
+    // Offline or file:// contexts may block fetch; respect fallback strategy.
+    return { manifest: null, baseUrl, message: "Manifest unavailable; relying on fallback art." };
+  }
+}
+
+function resolveBaseUrl(path) {
+  try {
+    return new URL(path, window.location.href);
+  } catch (error) {
+    return new URL(window.location.href);
+  }
+}
+
+function normalizeHero(hero, baseUrl) {
+  if (!hero || typeof hero !== "object") {
+    return null;
+  }
+  const rawSrc = typeof hero.src === "string" ? hero.src.trim() : "";
+  if (!rawSrc) {
+    return null;
+  }
+  const alt = typeof hero.alt === "string" ? hero.alt : "";
+  return {
+    src: resolveSource(rawSrc, baseUrl),
+    alt
+  };
+}
+
+function resolveSource(src, baseUrl) {
+  if (src.startsWith("data:")) {
+    return src;
+  }
+  try {
+    const resolved = new URL(src, baseUrl);
+    return resolved.href;
+  } catch (error) {
+    return src;
+  }
+}
+
+function buildHeroImage(hero) {
+  const img = new Image();
+  img.loading = "eager";
+  img.decoding = "async";
+  img.src = hero.src;
+  img.alt = hero.alt;
+  img.style.display = "block";
+  img.style.maxWidth = "100%";
+  img.style.margin = "0 auto";
+  img.style.boxShadow = "0 0 0 1px #1d1d2a";
+  return img;
+}
+
+function updateStatus(element, message) {
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+}
+
+function triggerFallback(opts, message) {
+  updateStatus(opts.statusElement, message);
+  if (typeof opts.onFallback === "function") {
+    opts.onFallback(message);
+  }
+}

--- a/assets/js/first-paint-octagram.js
+++ b/assets/js/first-paint-octagram.js
@@ -1,0 +1,52 @@
+/*
+  first-paint-octagram.js
+  Renders a static octagram field as a first-paint fallback when hero art is unavailable.
+  ND-safe: no motion, soft gradient, clear geometry for grounding without overstimulation.
+*/
+
+export function paintOctagram(id = "opus", width = 1200, height = 675) {
+  const canvas = document.getElementById(id);
+  if (!canvas) {
+    return false;
+  }
+
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return false;
+  }
+
+  // Gentle radial gradient evokes chapel lighting without flashing.
+  const gradient = ctx.createRadialGradient(
+    width / 2,
+    height / 2,
+    40,
+    width / 2,
+    height / 2,
+    Math.hypot(width, height) / 2
+  );
+  const palette = ["#0F0B1E", "#1d1d20", "#3b2e5a", "#bfa66b", "#dfe8ff"];
+  palette.forEach((color, index) => {
+    gradient.addColorStop(index / (palette.length - 1), color);
+  });
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  // Octagram lines remain static to respect the no-animation covenant.
+  ctx.globalAlpha = 0.25;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = "#dfe8ff";
+  const radius = Math.min(width, height) * 0.32;
+  const cx = width / 2;
+  const cy = height / 2;
+  for (let k = 0; k < 8; k += 1) {
+    const angle = (Math.PI / 4) * k;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx + radius * Math.cos(angle), cy + radius * Math.sin(angle));
+    ctx.stroke();
+  }
+  return true;
+}

--- a/core/health-check.html
+++ b/core/health-check.html
@@ -1,14 +1,11 @@
-<!doctype html><meta charset="utf-8"><title>Health</title>
-<style>body{font:14px/1.4 ui-serif,Georgia,serif;padding:1rem}.ok{color:#0a0}.bad{color:#a00}</style>
-<ul id="r"></ul>
+<!doctype html><meta charset="utf-8"><title>Cathedral Health ✓</title>
+<style>body{font:14px ui-monospace,monospace;background:#0b0c10;color:#e6e6e6;padding:2rem}</style>
+<h1>Cathedral Health ✓</h1>
+<ul>
+  <li>Build: <script>document.write(new Date(document.lastModified).toISOString())</script></li>
+  <li>Auth: <span id="auth">none</span></li>
+</ul>
 <script>
-const tests = ["index.html"];
-Promise.allSettled(tests.map(t => fetch(t,{method:"HEAD"}))).then(rs=>{
-  const r=document.getElementById('r');
-  rs.forEach((x,i)=>{const li=document.createElement('li');
-    li.className = x.status==="fulfilled" && x.value.ok ? "ok" : "bad";
-    li.textContent = tests[i] + " → " + (x.status==="fulfilled"?x.value.status:x.reason);
-    r.appendChild(li);
-  });
-});
+  const gated = document.cookie.includes('nf_jwt') || !!window.netlifyIdentity;
+  if (gated) document.getElementById('auth').textContent = 'possible gate detected';
 </script>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,13 @@
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
     html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .status-list { list-style:none; margin:8px 0 0; padding:0; display:flex; flex-wrap:wrap; gap:12px; font-size:12px; color:var(--muted); }
+    .status-list li { margin:0; }
+    main { max-width:1200px; margin:0 auto; padding:16px; display:flex; flex-direction:column; gap:24px; }
+    #opus, #stage { display:block; margin:0 auto; box-shadow:0 0 0 1px #1d1d2a; }
+    #opus { max-width:100%; height:auto; }
+    #hero-art { min-height:24px; text-align:center; color:var(--muted); font-size:13px; }
+    #hero-art img { display:block; margin:0 auto; max-width:100%; height:auto; }
     .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
@@ -19,18 +24,55 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <ul class="status-list">
+      <li id="status">Loading palette...</li>
+      <li id="hero-status">Preparing hero art fallback...</li>
+    </ul>
   </header>
 
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <main>
+    <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
+    <div id="hero-art" aria-live="polite">Hero art pending.</div>
+    <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+    <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+  </main>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
+    import { paintOctagram } from "./assets/js/first-paint-octagram.js";
+    import { mountArt } from "./assets/js/art-loader.js";
 
-    const elStatus = document.getElementById("status");
-    const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
+    const paletteStatus = document.getElementById("status");
+    const heroStatus = document.getElementById("hero-status");
+    const heroHost = document.getElementById("hero-art");
+    const stageCanvas = document.getElementById("stage");
+    const stageCtx = stageCanvas.getContext("2d");
+
+    paintOctagram();
+
+    const notices = [];
+    const heroMessages = new Set();
+
+    function noteHeroFallback(message) {
+      if (heroHost) {
+        heroHost.textContent = message;
+      }
+      if (!heroMessages.has(message)) {
+        notices.push(message);
+        heroMessages.add(message);
+      }
+    }
+
+    const heroResult = await mountArt({
+      manifestPath: "./assets/art/manifest.json",
+      targetId: "hero-art",
+      statusElement: heroStatus,
+      onFallback: noteHeroFallback
+    });
+
+    if (!heroResult && heroHost && heroMessages.size === 0) {
+      noteHeroFallback("Hero art offline; octagram fallback on duty.");
+    }
 
     async function loadJSON(path) {
       // Offline assurance: avoid fetch when opened via file:// to honor the no-network brief.
@@ -46,7 +88,7 @@
       }
     }
 
-    function mergePalette(defaultPalette, overridePalette, notices) {
+    function mergePalette(defaultPalette, overridePalette, log) {
       const base = { ...defaultPalette, layers: [...defaultPalette.layers] };
       if (!overridePalette || typeof overridePalette !== "object") {
         return base;
@@ -55,13 +97,13 @@
       if (typeof overridePalette.bg === "string") {
         base.bg = overridePalette.bg;
       } else {
-        notices.push("Palette missing bg; using default.");
+        log.push("Palette missing bg; using default.");
       }
 
       if (typeof overridePalette.ink === "string") {
         base.ink = overridePalette.ink;
       } else {
-        notices.push("Palette missing ink; using default.");
+        log.push("Palette missing ink; using default.");
       }
 
       if (Array.isArray(overridePalette.layers)) {
@@ -69,11 +111,11 @@
           if (typeof overridePalette.layers[i] === "string") {
             base.layers[i] = overridePalette.layers[i];
           } else if (overridePalette.layers[i] !== undefined) {
-            notices.push("Palette layer " + (i + 1) + " invalid; using default.");
+            log.push("Palette layer " + (i + 1) + " invalid; using default.");
           }
         }
       } else {
-        notices.push("Palette layers missing; using defaults.");
+        log.push("Palette layers missing; using defaults.");
       }
 
       return base;
@@ -87,19 +129,18 @@
       }
     };
 
-    const notices = [];
-    const palette = await loadJSON("./data/palette.json");
-    const active = mergePalette(defaults.palette, palette, notices);
+    const paletteData = await loadJSON("./data/palette.json");
+    const activePalette = mergePalette(defaults.palette, paletteData, notices);
 
-    if (palette) {
-      elStatus.textContent = "Palette loaded.";
+    if (paletteData) {
+      paletteStatus.textContent = "Palette loaded.";
     } else {
-      elStatus.textContent = "Palette missing; using safe fallback.";
+      paletteStatus.textContent = "Palette missing; using safe fallback.";
       notices.push("Palette JSON not available; calm defaults engaged.");
     }
 
-    if (!ctx) {
-      elStatus.textContent = "2D canvas context unavailable.";
+    if (!stageCtx) {
+      paletteStatus.textContent = "2D canvas context unavailable.";
       notices.push("Canvas context unavailable; nothing rendered.");
       return;
     }
@@ -108,7 +149,7 @@
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices });
+    renderHelix(stageCtx, { width:stageCanvas.width, height:stageCanvas.height, palette:activePalette, NUM, notices });
   </script>
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,4 @@
 
 [build.environment]
   GIT_LFS_ENABLED = "false"
+  GIT_LFS_SKIP_SMUDGE = "1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tesseract-bridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prebuild": "node scripts/verify-absent.mjs",
+    "build": "vite build"
+  }
+}

--- a/scripts/verify-absent.mjs
+++ b/scripts/verify-absent.mjs
@@ -1,0 +1,16 @@
+/*
+  verify-absent.mjs
+  ND-safe guard: ensures forbidden PNG assets stay absent to prevent accidental resurrection.
+*/
+
+import { existsSync } from "node:fs";
+
+const tombs = ["assets/art/black-madonna-altar-1600.png"];
+const risen = tombs.filter((path) => existsSync(path));
+
+if (risen.length > 0) {
+  console.error("PROTECT violation: undead asset(s) present:", risen);
+  process.exit(1);
+} else {
+  console.log("Guard ok — no undead assets detected.");
+}


### PR DESCRIPTION
## Summary
- block Git LFS smudging for PNG assets and add a guard script plus npm hooks to fail builds if the Black Madonna PNG returns
- introduce an offline-safe hero art manifest, loader, and octagram first paint with updated index wiring and Netlify env override
- refresh renderer documentation and health check instructions for the new WEBP-only flow

## Testing
- node scripts/verify-absent.mjs

------
https://chatgpt.com/codex/tasks/task_e_68ce54bfb2b88328a7f4849aa2442ff2