### PR TITLE
Add realm link registry and bridge health endpoints

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,24 +3,20 @@
 Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
 
 ## Files
-- `index.html` – entry document that sets up the canvases, altar loader, and helix renderer.
+- `index.html` – entry document that sets up the canvas and helix renderer.
 - `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
-- `assets/js/first-paint-octagram.js` – draws the octagram first paint while altar art resolves.
-- `assets/js/art-loader.js` – fetches the WEBP manifest and mounts the hero art when available.
-- `assets/art/manifest.json` – declares the hero WEBP and policy guardrails.
 - `data/palette.json` – optional palette override; missing file triggers a safe fallback notice.
 - `README_RENDERER.md` – this usage guide.
 
 ## Usage
 1. Keep all files in the same directory structure.
 2. Double-click `index.html` (no server or network required).
-3. A WEBP altar attempts to load above the helix canvas. When offline or blocked, the octagram first paint remains active with a calm notice.
-4. A 1440x900 canvas renders, in order:
+3. A 1440x900 canvas renders, in order:
    - Vesica field
    - Tree-of-Life nodes and paths
    - Fibonacci curve
    - Static double-helix lattice
-5. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
+4. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
 
 ## Palette
 `data/palette.json` structure:
@@ -35,12 +31,10 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
 
 Edit the file to customize colors, or delete it to exercise the fallback notice.
 
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline
-notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a local
-server temporarily and open the same files there.
+When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a local server temporarily and open the same files there.
 
 ## ND-safe choices
-- No animation or autoplay; only optional local manifest fetches.
+- No animation or autoplay; only optional local palette merge.
 - Calm contrast, layered order, and generous spacing for readability.
 - Layer hierarchy (Vesica → Tree → Fibonacci → Helix) keeps geometry multi-layered rather than flattened.
 - Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144` to honor the cosmology brief.

--- a/bridge.js
+++ b/bridge.js
@@ -1,0 +1,71 @@
+/*
+  bridge.js
+  Tiny helper for remote realms to discover bridge links and check health.
+  ND-safe: small pure functions, offline-first defaults, ASCII quotes only.
+*/
+(function createBridgeIIFE() {
+  const script = typeof document !== "undefined" ? document.currentScript : null;
+  const baseHref = resolveBase(script);
+
+  function resolveBase(currentScript) {
+    /*
+      Pure resolver: determines the base URL for subsequent fetches. When no
+      script element is present, falls back to window location or root.
+    */
+    if (currentScript && currentScript.src) {
+      return new URL("./", currentScript.src).toString();
+    }
+    if (typeof window !== "undefined" && window.location) {
+      return window.location.origin + "/";
+    }
+    return "./";
+  }
+
+  function makeURL(path) {
+    return new URL(path, baseHref).toString();
+  }
+
+  async function fetchJSON(url) {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error("HTTP " + response.status);
+    }
+    return await response.json();
+  }
+
+  async function fetchText(url) {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error("HTTP " + response.status);
+    }
+    return await response.text();
+  }
+
+  function createBridge(base) {
+    /*
+      Exposes two pure async helpers:
+        - links(): fetches realm links JSON for discovery.
+        - ping(): fetches health check and reports status text + timestamp.
+    */
+    return {
+      async links() {
+        const data = await fetchJSON(makeURL("registry/realm_links.json"));
+        return { base, data };
+      },
+      async ping() {
+        const responseText = await fetchText(makeURL("core/health-check.html"));
+        return {
+          base,
+          ok: true,
+          received: new Date().toISOString(),
+          snippet: responseText.slice(0, 144)
+        };
+      }
+    };
+  }
+
+  const bridge = createBridge(baseHref);
+  if (typeof globalThis !== "undefined") {
+    globalThis.tesseractBridge = bridge;
+  }
+})();

--- a/core/health-check.html
+++ b/core/health-check.html
@@ -1,11 +1,30 @@
-<!doctype html><meta charset="utf-8"><title>Cathedral Health ✓</title>
-<style>body{font:14px ui-monospace,monospace;background:#0b0c10;color:#e6e6e6;padding:2rem}</style>
-<h1>Cathedral Health ✓</h1>
-<ul>
-  <li>Build: <script>document.write(new Date(document.lastModified).toISOString())</script></li>
-  <li>Auth: <span id="auth">none</span></li>
-</ul>
-<script>
-  const gated = document.cookie.includes('nf_jwt') || !!window.netlifyIdentity;
-  if (gated) document.getElementById('auth').textContent = 'possible gate detected';
-</script>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Tesseract Bridge — Health OK</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+    body{font:14px ui-monospace,monospace;background:#0b0c10;color:#e6e6e6;margin:0;padding:2rem;line-height:1.5}
+    h1{margin:0 0 1rem;font-size:1.5rem}
+    dl{margin:0 0 1.5rem}
+    dt{font-weight:600}
+    dd{margin:0 0 0.75rem}
+    a{color:#a6a6c1}
+  </style>
+</head>
+<body>
+  <h1>Tesseract Bridge — Health OK</h1>
+  <dl>
+    <dt>Last Modified</dt>
+    <dd><script>document.write(new Date(document.lastModified).toISOString())</script></dd>
+    <dt>Realm Links</dt>
+    <dd><a href="/registry/realm_links.json">/registry/realm_links.json</a></dd>
+    <dt>Bridge Script</dt>
+    <dd><a href="/bridge.js">/bridge.js</a></dd>
+    <dt>Event Log</dt>
+    <dd><a href="/events/2025-09-20.jsonl">/events/2025-09-20.jsonl</a></dd>
+  </dl>
+  <p>Offline-first pledge: endpoints stay static and require no authentication.</p>
+</body>
+</html>

--- a/events/2025-09-20.jsonl
+++ b/events/2025-09-20.jsonl
@@ -1,0 +1,3 @@
+{"type":"registry-update","repo":"tesseract-bridge","payload":{"file":"registry/realm_links.json","status":"created"},"version":1}
+{"type":"health-endpoint","repo":"tesseract-bridge","payload":{"path":"/core/health-check.html","status":"refreshed"},"version":1}
+{"type":"bridge-script","repo":"tesseract-bridge","payload":{"file":"/bridge.js","status":"published"},"version":1}

--- a/index.html
+++ b/index.html
@@ -10,137 +10,130 @@
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
     html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; display:flex; gap:12px; flex-wrap:wrap; }
-    #altar { max-width:1200px; margin:16px auto; display:flex; flex-direction:column; align-items:center; gap:12px; }
-    #opus { display:block; box-shadow:0 0 0 1px #1d1d2a; }
-    #hero-art { min-height:24px; display:flex; align-items:center; justify-content:center; flex-direction:column; gap:8px; text-align:center; }
-    #hero-art img { max-width:100%; height:auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
     .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
 </head>
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status"><span id="status">Loading palette…</span><span id="art-status">Preparing altar…</span></div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
-  <section id="altar" aria-label="Altar hero art with fallback octagram">
-    <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
-    <div id="hero-art" aria-live="polite"></div>
-  </section>
-
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. A WEBP altar loads when available; otherwise the octagram canvas remains as the first paint. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { paintOctagram } from "./assets/js/first-paint-octagram.js";
-    import { mountArt } from "./assets/js/art-loader.js";
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
-    const elArtStatus = document.getElementById("art-status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
     const notices = [];
 
-    // First paint fallback: static octagram while hero art resolves.
-    paintOctagram();
-    const artOutcome = await mountArt();
-    if (elArtStatus) {
-      const artMessages = {
-        "loaded": "Altar WEBP loaded.",
-        "offline-skip": "Offline mode: using octagram fallback.",
-        "manifest-missing": "Manifest missing hero entry; fallback active.",
-        "format-invalid": "Manifest hero rejected (must be WEBP).",
-        "fetch-error": "Manifest fetch failed; fallback active.",
-        "container-missing": "Altar container missing; fallback active.",
-        "image-error": "Hero WEBP failed to load; fallback active."
-      };
-      elArtStatus.textContent = artMessages[artOutcome] || "Fallback altar active.";
-    }
-    if (artOutcome && artOutcome !== "loaded") {
-      notices.push("Altar status: " + (elArtStatus ? elArtStatus.textContent : artOutcome));
+    function reportStatus(text) {
+      if (statusEl) {
+        statusEl.textContent = text;
+      }
     }
 
-    async function loadJSON(path) {
-      // Offline assurance: avoid fetch when opened via file:// to honor the no-network brief.
+    async function loadPalette(path) {
+      /*
+        Offline-first palette loader. Skips network fetches when opened via file://
+        per ND-safe brief and returns null so defaults engage.
+      */
       if (typeof window !== "undefined" && window.location && window.location.protocol === "file:") {
         return null;
       }
       try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-      } catch (err) {
+        const response = await fetch(path, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error("HTTP " + response.status);
+        }
+        return await response.json();
+      } catch (error) {
         return null;
       }
     }
 
-    function mergePalette(defaultPalette, overridePalette, paletteNotices) {
-      const base = { ...defaultPalette, layers: [...defaultPalette.layers] };
+    function mergePalette(defaultPalette, overridePalette) {
+      /*
+        Pure merge routine preserves defaults and records calm notices when
+        overrides are incomplete. Keeps geometry colors deterministic.
+      */
+      const merged = { ...defaultPalette, layers: [...defaultPalette.layers] };
       if (!overridePalette || typeof overridePalette !== "object") {
-        return base;
+        return merged;
       }
 
       if (typeof overridePalette.bg === "string") {
-        base.bg = overridePalette.bg;
+        merged.bg = overridePalette.bg;
       } else {
-        paletteNotices.push("Palette missing bg; using default.");
+        notices.push("Palette missing bg; using default.");
       }
 
       if (typeof overridePalette.ink === "string") {
-        base.ink = overridePalette.ink;
+        merged.ink = overridePalette.ink;
       } else {
-        paletteNotices.push("Palette missing ink; using default.");
+        notices.push("Palette missing ink; using default.");
       }
 
       if (Array.isArray(overridePalette.layers)) {
-        for (let i = 0; i < base.layers.length; i += 1) {
+        for (let i = 0; i < merged.layers.length; i += 1) {
           if (typeof overridePalette.layers[i] === "string") {
-            base.layers[i] = overridePalette.layers[i];
+            merged.layers[i] = overridePalette.layers[i];
           } else if (overridePalette.layers[i] !== undefined) {
-            paletteNotices.push("Palette layer " + (i + 1) + " invalid; using default.");
+            notices.push("Palette layer " + (i + 1) + " invalid; using default.");
           }
         }
       } else {
-        paletteNotices.push("Palette layers missing; using defaults.");
+        notices.push("Palette layers missing; using defaults.");
       }
 
-      return base;
+      return merged;
     }
 
     const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      bg: "#0b0b12",
+      ink: "#e8e8f0",
+      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
     };
 
-    const paletteNotices = [];
-    const palette = await loadJSON("./data/palette.json");
-    const active = mergePalette(defaults.palette, palette, paletteNotices);
+    const palette = await loadPalette("./data/palette.json");
+    const activePalette = mergePalette(defaults, palette);
 
-    if (palette) {
-      if (elStatus) elStatus.textContent = "Palette loaded.";
+    if (!palette) {
+      reportStatus("Palette missing; using safe fallback.");
+      notices.push("Palette JSON not available; calm defaults engaged.");
     } else {
-      if (elStatus) elStatus.textContent = "Palette missing; using safe fallback.";
-      paletteNotices.push("Palette JSON not available; calm defaults engaged.");
+      reportStatus("Palette loaded.");
     }
 
     if (!ctx) {
-      if (elStatus) elStatus.textContent = "2D canvas context unavailable.";
+      reportStatus("2D canvas context unavailable.");
       notices.push("Canvas context unavailable; nothing rendered.");
-      return;
+    } else {
+      const NUM = {
+        THREE: 3,
+        SEVEN: 7,
+        NINE: 9,
+        ELEVEN: 11,
+        TWENTYTWO: 22,
+        THIRTYTHREE: 33,
+        NINETYNINE: 99,
+        ONEFORTYFOUR: 144
+      };
+
+      // ND-safe rationale: no motion, soft contrast, layered order preserved.
+      renderHelix(ctx, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: activePalette,
+        NUM,
+        notices
+      });
     }
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices:[...notices, ...paletteNotices] });
   </script>
 </body>
 </html>

--- a/registry/realm_links.json
+++ b/registry/realm_links.json
@@ -1,0 +1,93 @@
+{
+  "cosmogenesis-learning-engine": {
+    "title": "Cosmogenesis Learning Engine",
+    "role": "Mind toggles and resonance maps",
+    "live": "https://cosmogenesis-learning-engine.netlify.app/",
+    "paths": {
+      "home": "/",
+      "chapels": "/chapels/",
+      "toggles": "/toggles/",
+      "resonance": "/resonance/manifest.json"
+    },
+    "last_sync": "2025-09-20"
+  },
+  "stone-grimoire": {
+    "title": "Stone Grimoire",
+    "role": "Geometry provenance and spiral palettes",
+    "live": "https://stone-grimoire.netlify.app/",
+    "paths": {
+      "home": "/",
+      "geometry_manifest": "/export/geometry_manifest.json",
+      "palette_manifest": "/export/spiral_palettes.json"
+    },
+    "last_sync": "2025-09-20"
+  },
+  "circuitum99": {
+    "title": "Circuitum99",
+    "role": "Soul archive and CSL citations",
+    "live": "https://circuitum99.netlify.app/",
+    "paths": {
+      "home": "/",
+      "bibliography": "/bibliography/",
+      "lattice": "/lattice/"
+    },
+    "last_sync": "2025-09-20"
+  },
+  "liber-arcanae": {
+    "title": "Liber Arcanae",
+    "role": "Tarot codex (canon)",
+    "live": "https://liber-arcanae.netlify.app/",
+    "paths": {
+      "home": "/",
+      "canon": "/canon/",
+      "gallery": "/gallery/",
+      "manifests": "/data/cards/manifest.json"
+    },
+    "last_sync": "2025-09-20"
+  },
+  "liber-arcanae-game": {
+    "title": "Liber Arcanae Game",
+    "role": "Playable study deck",
+    "live": "https://liber-arcanae-game.netlify.app/",
+    "paths": {
+      "home": "/",
+      "deck": "/deck/",
+      "state_manifest": "/manifests/deck-state.json",
+      "tree_paths": "/manifests/tree-of-life.json"
+    },
+    "last_sync": "2025-09-20"
+  },
+  "stone-cathedral": {
+    "title": "Stone Cathedral",
+    "role": "Labyrinth rooms",
+    "live": "https://stone-cathedral.netlify.app/",
+    "paths": {
+      "home": "/",
+      "rooms": "/rooms/",
+      "changelog": "/docs/changelog.html"
+    },
+    "last_sync": "2025-09-20"
+  },
+  "magical-mystery-house": {
+    "title": "Magical Mystery House",
+    "role": "Labyrinth wormholes",
+    "live": "https://magical-mystery-house.netlify.app/",
+    "paths": {
+      "home": "/",
+      "rooms": "/rooms/",
+      "wormholes": "/wormholes/"
+    },
+    "last_sync": "2025-09-20"
+  },
+  "codex-14499": {
+    "title": "Codex 14499",
+    "role": "144-node spiral reference",
+    "live": "https://codex-14499.netlify.app/",
+    "paths": {
+      "home": "/",
+      "nodes": "/nodes/",
+      "spheres": "/spheres/"
+    },
+    "last_sync": "2025-09-20"
+  }
+}


### PR DESCRIPTION
## Summary
- publish a realm links registry that lists live URLs for each cathedral site
- add a bridge helper script, daily event log, and refreshed health check endpoint for status pulses
- simplify the offline helix renderer and documentation to honour the no-network brief

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf14a7aea083288bb71157a1d611ed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a lightweight bridge for connectivity checks and fetching realm links.
  - Added a richer health-check page with status details, helpful links, and offline-first notes.
  - Published a registry of realms with live links, key paths, and sync timestamps.
- Refactor
  - Simplified the homepage: unified status display, streamlined palette loading/merging, and removed legacy art loader.
- Documentation
  - Updated README for simplified setup and clearer palette guidance with an example.
- Chores
  - Recorded release events for registry, health check, and bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->