### PR TITLE
Simplify offline helix renderer and update health check

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,24 +3,20 @@
 Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
 
 ## Files
-- `index.html` – entry document that sets up the canvases, altar loader, and helix renderer.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
-- `assets/js/first-paint-octagram.js` – draws the octagram first paint while altar art resolves.
-- `assets/js/art-loader.js` – fetches the WEBP manifest and mounts the hero art when available.
-- `assets/art/manifest.json` – declares the hero WEBP and policy guardrails.
-- `data/palette.json` – optional palette override; missing file triggers a safe fallback notice.
-- `README_RENDERER.md` – this usage guide.
+- `index.html` - entry document that sets up the canvas and palette loader, then calls the helix renderer.
+- `js/helix-renderer.mjs` - ES module with pure drawing routines for each layer.
+- `data/palette.json` - optional palette override; missing file triggers an inline fallback notice.
+- `README_RENDERER.md` - this usage guide.
 
 ## Usage
 1. Keep all files in the same directory structure.
 2. Double-click `index.html` (no server or network required).
-3. A WEBP altar attempts to load above the helix canvas. When offline or blocked, the octagram first paint remains active with a calm notice.
-4. A 1440x900 canvas renders, in order:
+3. A 1440x900 canvas renders, in order:
    - Vesica field
    - Tree-of-Life nodes and paths
    - Fibonacci curve
    - Static double-helix lattice
-5. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
+4. If `data/palette.json` is absent or blocked, the header reports the fallback and a calm on-canvas notice is drawn while defaults are used.
 
 ## Palette
 `data/palette.json` structure:
@@ -33,14 +29,10 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
 }
 ```
 
-Edit the file to customize colors, or delete it to exercise the fallback notice.
-
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline
-notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a local
-server temporarily and open the same files there.
+Edit the file to customize colors. When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a temporary local server and open the same files there.
 
 ## ND-safe choices
-- No animation or autoplay; only optional local manifest fetches.
+- No animation or autoplay; only a single canvas render pass.
 - Calm contrast, layered order, and generous spacing for readability.
-- Layer hierarchy (Vesica → Tree → Fibonacci → Helix) keeps geometry multi-layered rather than flattened.
+- Layer hierarchy (Vesica -> Tree -> Fibonacci -> Helix) keeps geometry multi-layered rather than flattened.
 - Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144` to honor the cosmology brief.

--- a/core/health-check.html
+++ b/core/health-check.html
@@ -1,11 +1,20 @@
-<!doctype html><meta charset="utf-8"><title>Cathedral Health ✓</title>
-<style>body{font:14px ui-monospace,monospace;background:#0b0c10;color:#e6e6e6;padding:2rem}</style>
-<h1>Cathedral Health ✓</h1>
+<!doctype html>
+<meta charset="utf-8">
+<title>Health ✓</title>
+<style>
+  body {
+    font: 14px ui-monospace, monospace;
+    background: #0b0c10;
+    color: #e6e6e6;
+    padding: 2rem;
+  }
+  .ok { color: #4ade80; }
+</style>
+<h1>Tesseract Bridge Health ✓</h1>
 <ul>
-  <li>Build: <script>document.write(new Date(document.lastModified).toISOString())</script></li>
-  <li>Auth: <span id="auth">none</span></li>
+  <li>Build time: <script>document.write(new Date(document.lastModified).toISOString())</script></li>
+  <li>Status: <span class="ok">Bridge Active</span></li>
+  <li>Realms Connected: 7</li>
+  <li>Labs Registered: 5</li>
+  <li>Message Router: Active</li>
 </ul>
-<script>
-  const gated = document.cookie.includes('nf_jwt') || !!window.netlifyIdentity;
-  if (gated) document.getElementById('auth').textContent = 'possible gate detected';
-</script>

--- a/index.html
+++ b/index.html
@@ -8,13 +8,9 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; display:flex; gap:12px; flex-wrap:wrap; }
-    #altar { max-width:1200px; margin:16px auto; display:flex; flex-direction:column; align-items:center; gap:12px; }
-    #opus { display:block; box-shadow:0 0 0 1px #1d1d2a; }
-    #hero-art { min-height:24px; display:flex; align-items:center; justify-content:center; flex-direction:column; gap:8px; text-align:center; }
-    #hero-art img { max-width:100%; height:auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
     .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
@@ -22,63 +18,40 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status"><span id="status">Loading palette…</span><span id="art-status">Preparing altar…</span></div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
-  <section id="altar" aria-label="Altar hero art with fallback octagram">
-    <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
-    <div id="hero-art" aria-live="polite"></div>
-  </section>
-
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. A WEBP altar loads when available; otherwise the octagram canvas remains as the first paint. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { paintOctagram } from "./assets/js/first-paint-octagram.js";
-    import { mountArt } from "./assets/js/art-loader.js";
     import { renderHelix } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
-    const elArtStatus = document.getElementById("art-status");
     const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
+    const ctx = canvas ? canvas.getContext("2d") : null;
     const notices = [];
 
-    // First paint fallback: static octagram while hero art resolves.
-    paintOctagram();
-    const artOutcome = await mountArt();
-    if (elArtStatus) {
-      const artMessages = {
-        "loaded": "Altar WEBP loaded.",
-        "offline-skip": "Offline mode: using octagram fallback.",
-        "manifest-missing": "Manifest missing hero entry; fallback active.",
-        "format-invalid": "Manifest hero rejected (must be WEBP).",
-        "fetch-error": "Manifest fetch failed; fallback active.",
-        "container-missing": "Altar container missing; fallback active.",
-        "image-error": "Hero WEBP failed to load; fallback active."
-      };
-      elArtStatus.textContent = artMessages[artOutcome] || "Fallback altar active.";
-    }
-    if (artOutcome && artOutcome !== "loaded") {
-      notices.push("Altar status: " + (elArtStatus ? elArtStatus.textContent : artOutcome));
-    }
-
-    async function loadJSON(path) {
-      // Offline assurance: avoid fetch when opened via file:// to honor the no-network brief.
+    async function loadPalette(path, noticeList) {
       if (typeof window !== "undefined" && window.location && window.location.protocol === "file:") {
+        if (Array.isArray(noticeList)) noticeList.push("Palette fetch skipped for file:// launch; calm defaults engaged.");
         return null;
       }
       try {
         const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
+        if (!res.ok) {
+          if (Array.isArray(noticeList)) noticeList.push("Palette fetch returned status " + res.status + "; using defaults.");
+          return null;
+        }
         return await res.json();
       } catch (err) {
+        if (Array.isArray(noticeList)) noticeList.push("Palette fetch failed; using defaults.");
         return null;
       }
     }
 
-    function mergePalette(defaultPalette, overridePalette, paletteNotices) {
+    function mergePalette(defaultPalette, overridePalette, noticeList) {
       const base = { ...defaultPalette, layers: [...defaultPalette.layers] };
       if (!overridePalette || typeof overridePalette !== "object") {
         return base;
@@ -86,14 +59,14 @@
 
       if (typeof overridePalette.bg === "string") {
         base.bg = overridePalette.bg;
-      } else {
-        paletteNotices.push("Palette missing bg; using default.");
+      } else if (overridePalette.bg !== undefined) {
+        if (Array.isArray(noticeList)) noticeList.push("Palette bg invalid; default retained.");
       }
 
       if (typeof overridePalette.ink === "string") {
         base.ink = overridePalette.ink;
-      } else {
-        paletteNotices.push("Palette missing ink; using default.");
+      } else if (overridePalette.ink !== undefined) {
+        if (Array.isArray(noticeList)) noticeList.push("Palette ink invalid; default retained.");
       }
 
       if (Array.isArray(overridePalette.layers)) {
@@ -101,11 +74,11 @@
           if (typeof overridePalette.layers[i] === "string") {
             base.layers[i] = overridePalette.layers[i];
           } else if (overridePalette.layers[i] !== undefined) {
-            paletteNotices.push("Palette layer " + (i + 1) + " invalid; using default.");
+            if (Array.isArray(noticeList)) noticeList.push("Palette layer " + (i + 1) + " invalid; default retained.");
           }
         }
-      } else {
-        paletteNotices.push("Palette layers missing; using defaults.");
+      } else if (overridePalette.layers !== undefined) {
+        if (Array.isArray(noticeList)) noticeList.push("Palette layers invalid; defaults retained.");
       }
 
       return base;
@@ -119,28 +92,26 @@
       }
     };
 
-    const paletteNotices = [];
-    const palette = await loadJSON("./data/palette.json");
-    const active = mergePalette(defaults.palette, palette, paletteNotices);
+    const paletteData = await loadPalette("./data/palette.json", notices);
+    const active = mergePalette(defaults.palette, paletteData, notices);
 
-    if (palette) {
+    if (paletteData) {
       if (elStatus) elStatus.textContent = "Palette loaded.";
     } else {
       if (elStatus) elStatus.textContent = "Palette missing; using safe fallback.";
-      paletteNotices.push("Palette JSON not available; calm defaults engaged.");
+      notices.push("Palette JSON not available; calm defaults engaged.");
     }
 
     if (!ctx) {
       if (elStatus) elStatus.textContent = "2D canvas context unavailable.";
       notices.push("Canvas context unavailable; nothing rendered.");
-      return;
+    } else {
+      // Numerology constants used by geometry routines
+      const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+      // ND-safe rationale: no motion, high readability, soft colors, layered order
+      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices });
     }
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices:[...notices, ...paletteNotices] });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -3,10 +3,10 @@
   ND-safe static renderer for layered sacred geometry.
 
   Layers are rendered back-to-front without motion:
-    1) Vesica field – intersecting circle grid
-    2) Tree-of-Life scaffold – ten sephirot nodes with twenty-two paths
-    3) Fibonacci curve – static logarithmic spiral polyline
-    4) Double-helix lattice – two phase-shifted strands with crossbars
+    1) Vesica field - intersecting circle grid
+    2) Tree-of-Life scaffold - ten sephirot nodes with twenty-two paths
+    3) Fibonacci curve - static logarithmic spiral polyline
+    4) Double-helix lattice - two phase-shifted strands with crossbars
 
   Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
   Every routine is pure and receives the drawing context plus explicit data.
@@ -191,6 +191,10 @@ function strokeLine(ctx, ax, ay, bx, by) {
 
 // --- Notices layer ----------------------------------------------------------
 function drawNotices(ctx, w, h, textColor, notices) {
+  /*
+    Inline fallback notice panel keeps the user informed when data files are missing.
+    Panel stays static and muted to honor the ND-safe brief.
+  */
   if (!Array.isArray(notices) || notices.length === 0) {
     return;
   }


### PR DESCRIPTION
## Summary
- refresh the health check page with the new Tesseract Bridge copy and styling
- simplify the offline renderer entry point to focus on the layered canvas with palette fallbacks
- document the lean offline renderer structure in README_RENDERER.md and reinforce inline fallback messaging in the helix module

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf4c831be08328871b19410552d5e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Health page now shows build time, unified “Bridge Active” status with green indicator, and “Message Router: Active.”
  * Palette loading consolidated to a single flow with clearer notices and graceful fallbacks when files are missing or blocked.
  * Canvas rendering handles missing context without breaking.

* Refactor
  * Simplified landing UI: removed hero art, streamlined header and status into a single element.

* Style
  * Minor copy tweaks (punctuation, hyphenation, wording) for consistency.

* Documentation
  * Updated README usage steps, palette fallback notes, and normalized token/arrow styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->