### PR TITLE
Simplify offline helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,24 +3,20 @@
 Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
 
 ## Files
-- `index.html` – entry document that sets up the canvases, altar loader, and helix renderer.
+- `index.html` – entry document that sets up the canvas and palette fallback before invoking the helix renderer.
 - `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
-- `assets/js/first-paint-octagram.js` – draws the octagram first paint while altar art resolves.
-- `assets/js/art-loader.js` – fetches the WEBP manifest and mounts the hero art when available.
-- `assets/art/manifest.json` – declares the hero WEBP and policy guardrails.
-- `data/palette.json` – optional palette override; missing file triggers a safe fallback notice.
+- `data/palette.json` – optional palette override; missing file triggers a calm inline notice while defaults are used.
 - `README_RENDERER.md` – this usage guide.
 
 ## Usage
 1. Keep all files in the same directory structure.
 2. Double-click `index.html` (no server or network required).
-3. A WEBP altar attempts to load above the helix canvas. When offline or blocked, the octagram first paint remains active with a calm notice.
-4. A 1440x900 canvas renders, in order:
+3. A 1440x900 canvas renders, in order:
    - Vesica field
    - Tree-of-Life nodes and paths
    - Fibonacci curve
    - Static double-helix lattice
-5. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
+4. If `data/palette.json` is absent, the header reports the fallback and a muted on-canvas notice appears while defaults remain active.
 
 ## Palette
 `data/palette.json` structure:
@@ -35,12 +31,10 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
 
 Edit the file to customize colors, or delete it to exercise the fallback notice.
 
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline
-notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a local
-server temporarily and open the same files there.
+When launched via `file://`, browsers often block local fetches; the renderer therefore skips the palette request and uses the defaults automatically. To preview custom palettes without a server, tweak the defaults in `index.html` and re-open the file.
 
 ## ND-safe choices
-- No animation or autoplay; only optional local manifest fetches.
-- Calm contrast, layered order, and generous spacing for readability.
+- No animation or autoplay; the canvas paints once with layered geometry.
+- Calm contrast, layered order, and generous spacing preserve readability.
 - Layer hierarchy (Vesica → Tree → Fibonacci → Helix) keeps geometry multi-layered rather than flattened.
 - Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144` to honor the cosmology brief.

--- a/index.html
+++ b/index.html
@@ -8,13 +8,9 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; display:flex; gap:12px; flex-wrap:wrap; }
-    #altar { max-width:1200px; margin:16px auto; display:flex; flex-direction:column; align-items:center; gap:12px; }
-    #opus { display:block; box-shadow:0 0 0 1px #1d1d2a; }
-    #hero-art { min-height:24px; display:flex; align-items:center; justify-content:center; flex-direction:column; gap:8px; text-align:center; }
-    #hero-art img { max-width:100%; height:auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
     .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
@@ -23,49 +19,22 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status"><span id="status">Loading palette…</span><span id="art-status">Preparing altar…</span></div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
-  <section id="altar" aria-label="Altar hero art with fallback octagram">
-    <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
-    <div id="hero-art" aria-live="polite"></div>
-  </section>
-
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. A WEBP altar loads when available; otherwise the octagram canvas remains as the first paint. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { paintOctagram } from "./assets/js/first-paint-octagram.js";
-    import { mountArt } from "./assets/js/art-loader.js";
     import { renderHelix } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
-    const elArtStatus = document.getElementById("art-status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
     const notices = [];
 
-    // First paint fallback: static octagram while hero art resolves.
-    paintOctagram();
-    const artOutcome = await mountArt();
-    if (elArtStatus) {
-      const artMessages = {
-        "loaded": "Altar WEBP loaded.",
-        "offline-skip": "Offline mode: using octagram fallback.",
-        "manifest-missing": "Manifest missing hero entry; fallback active.",
-        "format-invalid": "Manifest hero rejected (must be WEBP).",
-        "fetch-error": "Manifest fetch failed; fallback active.",
-        "container-missing": "Altar container missing; fallback active.",
-        "image-error": "Hero WEBP failed to load; fallback active."
-      };
-      elArtStatus.textContent = artMessages[artOutcome] || "Fallback altar active.";
-    }
-    if (artOutcome && artOutcome !== "loaded") {
-      notices.push("Altar status: " + (elArtStatus ? elArtStatus.textContent : artOutcome));
-    }
-
     async function loadJSON(path) {
-      // Offline assurance: avoid fetch when opened via file:// to honor the no-network brief.
+      // Offline assurance: skip fetch entirely when opened via file:// to avoid blocked network calls.
       if (typeof window !== "undefined" && window.location && window.location.protocol === "file:") {
         return null;
       }
@@ -78,22 +47,26 @@
       }
     }
 
-    function mergePalette(defaultPalette, overridePalette, paletteNotices) {
+    function sanitizePalette(defaultPalette, overridePalette, paletteNotices) {
+      // Pure function: clones defaults, applies overrides when valid, records calm notices otherwise.
       const base = { ...defaultPalette, layers: [...defaultPalette.layers] };
       if (!overridePalette || typeof overridePalette !== "object") {
+        if (overridePalette !== null && overridePalette !== undefined) {
+          paletteNotices.push("Palette object invalid; defaults retained.");
+        }
         return base;
       }
 
       if (typeof overridePalette.bg === "string") {
         base.bg = overridePalette.bg;
-      } else {
-        paletteNotices.push("Palette missing bg; using default.");
+      } else if (overridePalette.bg !== undefined) {
+        paletteNotices.push("Palette bg invalid; default shade kept.");
       }
 
       if (typeof overridePalette.ink === "string") {
         base.ink = overridePalette.ink;
-      } else {
-        paletteNotices.push("Palette missing ink; using default.");
+      } else if (overridePalette.ink !== undefined) {
+        paletteNotices.push("Palette ink invalid; default ink kept.");
       }
 
       if (Array.isArray(overridePalette.layers)) {
@@ -101,11 +74,11 @@
           if (typeof overridePalette.layers[i] === "string") {
             base.layers[i] = overridePalette.layers[i];
           } else if (overridePalette.layers[i] !== undefined) {
-            paletteNotices.push("Palette layer " + (i + 1) + " invalid; using default.");
+            paletteNotices.push("Palette layer " + (i + 1) + " invalid; default used.");
           }
         }
-      } else {
-        paletteNotices.push("Palette layers missing; using defaults.");
+      } else if (overridePalette.layers !== undefined) {
+        paletteNotices.push("Palette layers invalid; defaults used.");
       }
 
       return base;
@@ -119,19 +92,25 @@
       }
     };
 
-    const paletteNotices = [];
     const palette = await loadJSON("./data/palette.json");
-    const active = mergePalette(defaults.palette, palette, paletteNotices);
+    const paletteNotices = [];
+    const active = sanitizePalette(defaults.palette, palette, paletteNotices);
 
-    if (palette) {
-      if (elStatus) elStatus.textContent = "Palette loaded.";
+    if (palette && paletteNotices.length === 0) {
+      elStatus.textContent = "Palette loaded.";
+    } else if (palette && paletteNotices.length > 0) {
+      elStatus.textContent = "Palette adjusted; see notice.";
+      notices.push(...paletteNotices);
     } else {
-      if (elStatus) elStatus.textContent = "Palette missing; using safe fallback.";
-      paletteNotices.push("Palette JSON not available; calm defaults engaged.");
+      elStatus.textContent = "Palette missing; using safe fallback.";
+      if (paletteNotices.length > 0) {
+        notices.push(...paletteNotices);
+      }
+      notices.push("Palette JSON not available; calm defaults engaged.");
     }
 
     if (!ctx) {
-      if (elStatus) elStatus.textContent = "2D canvas context unavailable.";
+      elStatus.textContent = "2D canvas context unavailable.";
       notices.push("Canvas context unavailable; nothing rendered.");
       return;
     }
@@ -140,7 +119,7 @@
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices:[...notices, ...paletteNotices] });
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- streamline the index page to rely solely on the helix renderer module and provide palette fallback notices
- add palette sanitization to preserve ND-safe defaults when overrides are invalid or absent
- refresh the renderer README to match the simplified offline flow

## Testing
- not run (static HTML renderer)


------
https://chatgpt.com/codex/tasks/task_e_68cf49c3d3708328a6eb855cf51fd8f7