### PR TITLE
Refine offline helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,24 +3,20 @@
 Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
 
 ## Files
-- `index.html` – entry document that sets up the canvases, altar loader, and helix renderer.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
-- `assets/js/first-paint-octagram.js` – draws the octagram first paint while altar art resolves.
-- `assets/js/art-loader.js` – fetches the WEBP manifest and mounts the hero art when available.
-- `assets/art/manifest.json` – declares the hero WEBP and policy guardrails.
-- `data/palette.json` – optional palette override; missing file triggers a safe fallback notice.
-- `README_RENDERER.md` – this usage guide.
+- `index.html` - entry document that mounts the 1440x900 canvas and calls the renderer module.
+- `js/helix-renderer.mjs` - ES module with pure drawing routines for each layer.
+- `data/palette.json` - optional palette override consumed via JSON modules; missing files trigger a calm fallback.
+- `README_RENDERER.md` - this usage guide.
 
 ## Usage
 1. Keep all files in the same directory structure.
 2. Double-click `index.html` (no server or network required).
-3. A WEBP altar attempts to load above the helix canvas. When offline or blocked, the octagram first paint remains active with a calm notice.
-4. A 1440x900 canvas renders, in order:
-   - Vesica field
+3. A single canvas renders, in order:
+   - Vesica field (intersecting grid)
    - Tree-of-Life nodes and paths
    - Fibonacci curve
    - Static double-helix lattice
-5. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
+4. The header reports whether the optional palette loaded. Missing or unsupported JSON modules fall back to defaults, and the canvas prints a small notice box for clarity.
 
 ## Palette
 `data/palette.json` structure:
@@ -33,14 +29,11 @@ Static, offline HTML + Canvas composition layering four sacred geometry systems.
 }
 ```
 
-Edit the file to customize colors, or delete it to exercise the fallback notice.
-
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline
-notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a local
-server temporarily and open the same files there.
+Edit the file to customize colors. Browsers that support JSON modules (modern Chromium, Firefox, and Safari) will load the palette even when opened via `file://`. Older browsers fall back gracefully while drawing the notice overlay.
 
 ## ND-safe choices
-- No animation or autoplay; only optional local manifest fetches.
+- No animation or autoplay; only a single render pass.
 - Calm contrast, layered order, and generous spacing for readability.
-- Layer hierarchy (Vesica → Tree → Fibonacci → Helix) keeps geometry multi-layered rather than flattened.
+- Layer hierarchy (Vesica -> Tree -> Fibonacci -> Helix) keeps geometry multi-layered rather than flattened.
 - Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144` to honor the cosmology brief.
+- Notices appear inside muted panels to communicate fallbacks without flashing or startling color shifts.

--- a/index.html
+++ b/index.html
@@ -10,11 +10,7 @@
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
     html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; display:flex; gap:12px; flex-wrap:wrap; }
-    #altar { max-width:1200px; margin:16px auto; display:flex; flex-direction:column; align-items:center; gap:12px; }
-    #opus { display:block; box-shadow:0 0 0 1px #1d1d2a; }
-    #hero-art { min-height:24px; display:flex; align-items:center; justify-content:center; flex-direction:column; gap:8px; text-align:center; }
-    #hero-art img { max-width:100%; height:auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
     .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
@@ -22,78 +18,60 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status"><span id="status">Loading palette…</span><span id="art-status">Preparing altar…</span></div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
-  <section id="altar" aria-label="Altar hero art with fallback octagram">
-    <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
-    <div id="hero-art" aria-live="polite"></div>
-  </section>
-
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. A WEBP altar loads when available; otherwise the octagram canvas remains as the first paint. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { paintOctagram } from "./assets/js/first-paint-octagram.js";
-    import { mountArt } from "./assets/js/art-loader.js";
     import { renderHelix } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
-    const elArtStatus = document.getElementById("art-status");
     const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
-    const notices = [];
 
-    // First paint fallback: static octagram while hero art resolves.
-    paintOctagram();
-    const artOutcome = await mountArt();
-    if (elArtStatus) {
-      const artMessages = {
-        "loaded": "Altar WEBP loaded.",
-        "offline-skip": "Offline mode: using octagram fallback.",
-        "manifest-missing": "Manifest missing hero entry; fallback active.",
-        "format-invalid": "Manifest hero rejected (must be WEBP).",
-        "fetch-error": "Manifest fetch failed; fallback active.",
-        "container-missing": "Altar container missing; fallback active.",
-        "image-error": "Hero WEBP failed to load; fallback active."
+    async function loadPaletteModule(path) {
+      /*
+        Offline-first: JSON module import avoids network fetches.
+        Missing files or unsupported JSON modules fall back to defaults.
+      */
+      const result = {
+        palette: null,
+        statusText: "Palette missing; using safe fallback.",
+        notices: []
       };
-      elArtStatus.textContent = artMessages[artOutcome] || "Fallback altar active.";
-    }
-    if (artOutcome && artOutcome !== "loaded") {
-      notices.push("Altar status: " + (elArtStatus ? elArtStatus.textContent : artOutcome));
-    }
-
-    async function loadJSON(path) {
-      // Offline assurance: avoid fetch when opened via file:// to honor the no-network brief.
-      if (typeof window !== "undefined" && window.location && window.location.protocol === "file:") {
-        return null;
-      }
       try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-      } catch (err) {
-        return null;
+        const module = await import(path, { assert: { type: "json" } });
+        if (module && module.default && typeof module.default === "object") {
+          result.palette = module.default;
+          result.statusText = "Palette loaded.";
+        } else {
+          result.notices.push("Palette module invalid; calm defaults engaged.");
+        }
+      } catch (error) {
+        result.notices.push("Palette JSON unavailable or unsupported; calm defaults engaged.");
       }
+      return result;
     }
 
     function mergePalette(defaultPalette, overridePalette, paletteNotices) {
       const base = { ...defaultPalette, layers: [...defaultPalette.layers] };
       if (!overridePalette || typeof overridePalette !== "object") {
+        paletteNotices.push("Palette missing; defaults preserved.");
         return base;
       }
 
       if (typeof overridePalette.bg === "string") {
         base.bg = overridePalette.bg;
-      } else {
-        paletteNotices.push("Palette missing bg; using default.");
+      } else if (overridePalette.bg !== undefined) {
+        paletteNotices.push("Palette bg invalid; using default.");
       }
 
       if (typeof overridePalette.ink === "string") {
         base.ink = overridePalette.ink;
-      } else {
-        paletteNotices.push("Palette missing ink; using default.");
+      } else if (overridePalette.ink !== undefined) {
+        paletteNotices.push("Palette ink invalid; using default.");
       }
 
       if (Array.isArray(overridePalette.layers)) {
@@ -104,43 +82,63 @@
             paletteNotices.push("Palette layer " + (i + 1) + " invalid; using default.");
           }
         }
-      } else {
-        paletteNotices.push("Palette layers missing; using defaults.");
+      } else if (overridePalette.layers !== undefined) {
+        paletteNotices.push("Palette layers invalid; using defaults.");
       }
 
       return base;
     }
 
-    const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+    async function main() {
+      if (!canvas) {
+        if (elStatus) elStatus.textContent = "Canvas element missing.";
+        return;
       }
-    };
 
-    const paletteNotices = [];
-    const palette = await loadJSON("./data/palette.json");
-    const active = mergePalette(defaults.palette, palette, paletteNotices);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        if (elStatus) elStatus.textContent = "2D canvas context unavailable.";
+        return;
+      }
 
-    if (palette) {
-      if (elStatus) elStatus.textContent = "Palette loaded.";
-    } else {
-      if (elStatus) elStatus.textContent = "Palette missing; using safe fallback.";
-      paletteNotices.push("Palette JSON not available; calm defaults engaged.");
+      const defaults = {
+        palette: {
+          bg:"#0b0b12",
+          ink:"#e8e8f0",
+          layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+        }
+      };
+
+      const loadResult = await loadPaletteModule("./data/palette.json");
+      const paletteNotices = [...loadResult.notices];
+      const activePalette = mergePalette(defaults.palette, loadResult.palette, paletteNotices);
+
+      if (elStatus) {
+        elStatus.textContent = loadResult.statusText;
+      }
+
+      const NUM = {
+        THREE:3,
+        SEVEN:7,
+        NINE:9,
+        ELEVEN:11,
+        TWENTYTWO:22,
+        THIRTYTHREE:33,
+        NINETYNINE:99,
+        ONEFORTYFOUR:144
+      };
+
+      // ND-safe rationale: no motion, high readability, layered depth maintained
+      renderHelix(ctx, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: activePalette,
+        NUM,
+        notices: paletteNotices
+      });
     }
 
-    if (!ctx) {
-      if (elStatus) elStatus.textContent = "2D canvas context unavailable.";
-      notices.push("Canvas context unavailable; nothing rendered.");
-      return;
-    }
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices:[...notices, ...paletteNotices] });
+    main();
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -3,10 +3,10 @@
   ND-safe static renderer for layered sacred geometry.
 
   Layers are rendered back-to-front without motion:
-    1) Vesica field – intersecting circle grid
-    2) Tree-of-Life scaffold – ten sephirot nodes with twenty-two paths
-    3) Fibonacci curve – static logarithmic spiral polyline
-    4) Double-helix lattice – two phase-shifted strands with crossbars
+    1) Vesica field - intersecting circle grid
+    2) Tree-of-Life scaffold - ten sephirot nodes with twenty-two paths
+    3) Fibonacci curve - static logarithmic spiral polyline
+    4) Double-helix lattice - two phase-shifted strands with crossbars
 
   Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
   Every routine is pure and receives the drawing context plus explicit data.
@@ -135,7 +135,7 @@ function drawFibonacci(ctx, w, h, color, NUM) {
 // --- Layer 4: Double-helix lattice -----------------------------------------
 function drawHelix(ctx, w, h, colorA, colorB, NUM) {
   /*
-    Two static sine-based strands with crossbars every eleventh segment.
+    Two static sine-based strands with TWENTYTWO crossbars to echo the paths.
     Amplitude kept small for visual calm while preserving layered depth.
   */
   const segments = NUM.ONEFORTYFOUR;
@@ -166,9 +166,11 @@ function drawHelix(ctx, w, h, colorA, colorB, NUM) {
 
   ctx.strokeStyle = colorB;
   ctx.lineWidth = 1.5;
-  for (let i = 0; i <= segments; i += NUM.ELEVEN) {
-    const t = (i / segments) * Math.PI * NUM.THREE;
-    const x = i * stepX;
+  const rungCount = NUM.TWENTYTWO;
+  for (let i = 0; i <= rungCount; i += 1) {
+    const ratio = i / rungCount;
+    const t = ratio * Math.PI * NUM.THREE;
+    const x = ratio * w;
     const y1 = midY + Math.sin(t) * amplitude;
     const y2 = midY - Math.sin(t) * amplitude;
     strokeLine(ctx, x, y1, x, y2);


### PR DESCRIPTION
## Summary
- simplify the offline renderer entry page to rely solely on the helix module and JSON palette imports
- adjust helix drawing routines to honor the numerology crossbar count and keep the notice overlay
- refresh the renderer README to document the offline workflow and palette expectations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf4bef4e5083289a771f9d76db2588