### PR TITLE
Refocus renderer for Fly.io and clean offline canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,11 @@ Central connector for the Cathedral of Circuits. It tracks IDs, manifests, and c
 1. Run `python3 core/check_ids.py --bridge .` to confirm IDs resolve inside the bridge registry.
 2. Review `docs/curation_checklist.md` prior to shipping any Tarot rooms or cards.
 3. Open `index.html` directly to confirm the ND-safe renderer still layers Vesica, Tree-of-Life, Fibonacci, and helix without network calls.
+4. Review `docs/fly-deployment.md` for the Fly.io handoff plan before any external publishing.
+
+## Fly.io Prep Notes
+- This repository no longer ships Netlify configuration; manual deploys use `flyctl deploy --config fly.toml` when ready.
+- All files remain static to keep parity between local double-click previews and the Fly runtime.
+- Update `fly.toml` with the final app name only from a local terminal; never commit secrets or workflow automation.
 
 Keep all updates offline-first, trauma-informed, and layered—never flatten the Cathedral geometry.

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,260 +1,36 @@
-# Cosmic Helix Renderer & Integration Hub
+# Cosmic Helix Renderer (Offline, ND-safe)
 
-Static, offline HTML + Canvas composition layering four sacred geometry systems and an accompanying integration hub fed by the bridge manifest. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
-
-## Files
-- `index.html` – main document with integration hub layout, manifest-driven repo cards, and the helix renderer canvas.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each sacred geometry layer.
-- `data/palette.json` – optional palette override; missing file triggers a calm fallback notice.
-Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for
-ND safety and runs by simply opening `index.html`.
+A lightweight HTML + Canvas scene that layers four pieces of sacred geometry with
+calm, ND-safe colors. Open `index.html` directly; no tooling, bundlers, or
+network calls are required. The renderer breathes in four tiers that echo the
+Cathedral cosmology and keeps geometry multi-layered rather than flattened.
 
 ## Files
-=
-StaticStatic, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for
-ND safety and runs by simply opening `index.html`.
-
-## Files
->>>>>>>+main/codex/orga
-ex.html` – entry document that sets up the helix renderer and handles palette fallbacks.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
-- `data/palette.json` – optional palette override; missing file triggers a safe fallback notice.
-Static, offline HTML + Canvas composition that layers the vesica field, Tree-of-Life scaffold, Fibonacci sweep, and a static double-helix lattice. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
-
-## Files
-- `index.html` – entry document that sets up the canvas, loads the palette, and calls the renderer.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer plus fallback notice rendering.
-- `data/palette.json` – optional palette override; missing file triggers a calm fallback notice and defaults.
-- `README_RENDERER.md` – this usage guide.
-Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for
-ND safety and runs by simply opening `index.html`.
-
-## Files
-- `index.html` - entry document that instantiates the 1440x900 canvas and loads the helix renderer module.
-- `js/helix-renderer.mjs` - ES module with pure drawing routines for each layer.
-- `data/palette.json` - optional palette override; missing file triggers a safe fallback notice.
-- `index.html` - entry document that sets up the canvas and palette loader, then calls the helix renderer.
-- `js/helix-renderer.mjs` - ES module with pure drawing routines for each layer.
-- `data/palette.json` - optional palette override; missing file triggers an inline fallback notice.
-- `README_RENDERER.md` - this usage guide.
+- `index.html` - entry document that loads the palette, reports status, and
+  invokes the renderer against a 1440x900 canvas.
+- `js/helix-renderer.mjs` - ES module with pure drawing functions for the
+  Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double helix.
+- `data/palette.json` - optional palette override; missing files trigger an
+  inline notice and calm defaults.
 
 ## Usage
-1. Keep all files in the same directory structure.
-2. Double-click `index.html` (no server or network required).
-<<<<<<< main
-3. The 3. The Integration Hub section reads `registry/notes/bridge_manifest.json` via JSON modules and renders one card per repo. Missing data produces a gentle inline notice and keeps the layout calm.
-4. A 1440x900 canvas renders, in order:
->>>>>>>+main
-/codex/organize-project-directory-structure
-3. A 1440x900 canvas renders, in order:
-   - Vesica field
-3. A 1440x900 canvas renders, in order:
-   - Vesica field (interlocking circles)
-   - Tree-of-Life nodes and paths
-   - Fibonacci curve
-   - Static double-helix lattice
-<<<<<<< main
-4. If `4. If `data/palette.json` is absent, the header reports the fallback and a calm on-canvas notice is drawn while defaults are used.
-4. If `data/palette.json` is absent or blocked, the header reports the fallback and a calm on-canvas notice is drawn while defaults are used.
+1. Keep the directory structure exactly as-is.
+2. Double-click `index.html`. Browsers opened via `file://` simply use the
+   default palette and annotate the canvas with the fallback notice.
+3. Update `data/palette.json` to experiment with colors. Remove it to verify the
+   fallback renders.
 
-When launched via `file://`, browsers often block local fetches. To respect the "no network" covenant, the loader skips fetches
-in that context and renders with the defaults plus the on-canvas notice. To preview custom palettes, either adjust the defaults
-inside `index.html` or launch a local server temporarily and open the same files there.
-4. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults
-are used.
-4. The header reports palette status. When the palette file is missing or blocked (common when opened via `file://`), a muted inline notice is drawn on the canvas while defaults are used.
->>>>>>>+main
-palette.4. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults
-are used.
->>>>>>>+main/codex/orga
-lette.json` structure:
+## Preparing for Fly.io
+- Manual deploys only. From a local terminal run:
+  - `flyctl launch --no-deploy` (once) to create the app configuration.
+  - `flyctl deploy --config fly.toml` when you are ready to publish.
+- Keep assets static. Fly will serve the same `index.html`, module, and data
+  files without build tooling.
+- The included `fly.toml` uses a minimal static file server so the offline-first
+  experience matches local double-click previews.
 
-```json
-{
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-}
-```
-
-Edit the file to customize colors, or delete it to exercise the fallback notice. The module import gracefully fails when the file is missing and records the fallback inside the canvas notices.
-
-## Manifest-driven cards
-- Repo cards derive from `registry/notes/bridge_manifest.json`. Update that manifest to change roles, status indicators, bridge focus, or notes.
-- Card titles use slug-friendly capitalization with optional overrides defined in `index.html`. Extend the override map if a repo needs a specific display name.
-- Link buttons use slug-based Netlify and GitHub URLs; adjust them in the script if a realm uses a different endpoint.
-
-## ND-safe choices
-<<<<<<< main
-- No an- No animation or autoplay; only local JSON module reads.
-## ND-safe choices
-- No animation or autoplay; only a single static canvas render.
-Edit the file to customize colors, or delete it to exercise the fallback notice. The renderer only fetches the palette when not running under `file://`; otherwise it applies the defaults immediately for offline safety.
-
-## ND-safe choices
-- No animation or autoplay; the canvas paints once on load.
-- Calm contrast, layered order, and generous spacing for readability.
-- Layer hierarchy (Vesica -> Tree -> Fibonacci -> Helix) keeps geometry multi-layered rather than flattened.
->>>>>>>+main
-/codex/organize-project-directory-structure
-- No animation or autoplay; static layering only.
-- Calm contrast, layered order, and generous spacing for readability.
-- Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144` to honor the cosmology brief.
-# Cosmic Helix Renderer & Integration Hub
-
-<<<<<<<+main
-Static, offline HTML + Canvas composition layering four sacred geometry systems and an accompanying integration hub fed by the bridge manifest. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
-
-## Files
-- `index.html` – main document with integration hub layout, manifest-driven repo cards, and the helix renderer canvas.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each sacred geometry layer.
-- `data/palette.json` – optional palette override; missing file triggers a calm fallback notice.
-Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for
-ND safety and runs by simply opening `index.html`.
-
-## Files
-=
-StaticStatic, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for
-ND safety and runs by simply opening `index.html`.
-
-## Files
->>>>>>>+main/codex/orga
-ex.html` – entry document that sets up the helix renderer and handles palette fallbacks.
-ry document that sets up the canvas and invokes the helix renderer.
->>>>>>> main/codex/add-error-handling-for-sendmessage-method
-- `index.html` – entry document that sets up the canvases, loads the renderer module, paints the octagram fallback, and mounts optional hero art.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
-- `assets/js/first-paint-octagram.js` – chapel-safe first paint to ensure a calm field if hero art is offline.
-- `assets/js/art-loader.js` – manifest-driven WEBP loader with ND-safe fallbacks.
-- `assets/art/manifest.json` – declares the live WEBP hero asset (relative paths keep it offline-friendly).
-- `data/palette.json` – optional palette override; missing file triggers a safe fallback notice.
-Static, offline HTML + Canvas composition that layers the vesica field, Tree-of-Life scaffold, Fibonacci sweep, and a static double-helix lattice. The scene avoids motion and harsh contrast for ND safety and runs by simply opening `index.html`.
-
-## Files
-- `index.html` – entry document that sets up the canvas, loads the palette, and calls the renderer.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer plus fallback notice rendering.
-- `data/palette.json` – optional palette override; missing file triggers a calm fallback notice and defaults.
-- `index.html` – entry document that sets up the canvas and palette fallback before invoking the helix renderer.
-- `js/helix-renderer.mjs` – ES module with pure drawing routines for each layer.
-- `data/palette.json` – optional palette override; missing file triggers a calm inline notice while defaults are used.
-- `scripts/verify-absent.mjs` – guard executed before builds to ensure forbidden PNG masters stay absent.
-- `README_RENDERER.md` – this usage guide.
-Static, offline HTML + Canvas composition layering four sacred geometry systems. The scene avoids motion and harsh contrast for
-ND safety and runs by simply opening `index.html`.
-
-## Files
-- `index.html` - entry document that instantiates the 1440x900 canvas and loads the helix renderer module.
-- `js/helix-renderer.mjs` - ES module with pure drawing routines for each layer.
-- `data/palette.json` - optional palette override; missing file triggers a safe fallback notice.
-- `index.html` - entry document that mounts the 1440x900 canvas and calls the renderer module.
-- `js/helix-renderer.mjs` - ES module with pure drawing routines for each layer.
-- `data/palette.json` - optional palette override consumed via JSON modules; missing files trigger a calm fallback.
-- `README_RENDERER.md` - this usage guide.
-
-## Usage
-1. Keep all files in the same directory structure.
-2. Double-click `index.html` (no server or network required).
-<<<<<<< main
-3. The 3. The Integration Hub section reads `registry/notes/bridge_manifest.json` via JSON modules and renders one card per repo. Missing data produces a gentle inline notice and keeps the layout calm.
-4. A 1440x900 canvas renders, in order:
->>>>>>>+main
-/codex/organize-project-directory-structure
-3. A 1440x900 canvas renders, in order:
-   - Vesica field
-3. A 1440x900 canvas renders, in order:
-   - Vesica field (interlocking circles)
-   - Tree-of-Life nodes and paths
-   - Fibonacci curve
-   - Static double-helix lattice
-<<<<<<< main
-4. If `4. If `data/palette.json` is absent, the header reports the fallback and a calm on-canvas notice is drawn while defaults are used.
-4. If `data/palette.json` is absent or malformed, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults are used.
-3. A single canvas renders, in order:
-   - Vesica field (intersecting grid)
-   - Tree-of-Life nodes and paths
-   - Fibonacci curve
-   - Static double-helix lattice
-<<<<<<< main
-4. The header reports whether the optional palette loaded. Missing or unsupported JSON modules fall back to defaults, and the canvas prints a small notice box for clarity.
-4. If `data/palette.json` is absent, the header reports the fallback and a muted on-canvas notice appears while defaults remain active.
-4. The octagram canvas (`#opus`) paints immediately, so visitors perceive the chapel geometry even if hero art or network requests stall.
-5. If `assets/art/black-madonna-altar-1600.webp` is present, the manifest loader displays it; otherwise `#hero-art` shows a calm fallback note while the octagram remains visible.
-6. The header status line reports palette or hero-art fallbacks as they happen, and `renderHelix` writes the same notes onto the geometry canvas.
-
-When launched via `file://`, browsers often block local fetches. To respect the "no network" covenant, the loader skips fetches
-in that context and renders with the defaults plus the on-canvas notice. To preview custom palettes, either adjust the defaults
-inside `index.html` or launch a local server temporarily and open the same files there.
-4. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults
-are used.
-4. The header reports palette status. When the palette file is missing or blocked (common when opened via `file://`), a muted inline notice is drawn on the canvas while defaults are used.
->>>>>>>+main
-palette.4. If `data/palette.json` is absent, the header reports the fallback and a calm inline notice is drawn on-canvas while defaults
-are used.
->>>>>>>+main/codex/orga
-lette.json` structure:
-
-```json
-{
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-}
-```
-
-Edit the file to customize colors, or delete it to exercise the fallback notice. The module import gracefully fails when the file is missing and records the fallback inside the canvas notices.
-
-## Manifest-driven cards
-- Repo cards derive from `registry/notes/bridge_manifest.json`. Update that manifest to change roles, status indicators, bridge focus, or notes.
-- Card titles use slug-friendly capitalization with optional overrides defined in `index.html`. Extend the override map if a repo needs a specific display name.
-- Link buttons use slug-based Netlify and GitHub URLs; adjust them in the script if a realm uses a different endpoint.
-
-## ND-safe choices
-<<<<<<< main
-- No an- No animation or autoplay; only local JSON module reads.
-## ND-safe choices
-- No animation or autoplay; only a single static canvas render.
-Edit the file to customize colors, or delete it to exercise the fallback notice. The renderer only fetches the palette when not running under `file://`; otherwise it applies the defaults immediately for offline safety.
-
-## ND-safe choices
-- No animation or autoplay; the canvas paints once on load.
-- Calm contrast, layered order, and generous spacing for readability.
-- Layer hierarchy (Vesica -> Tree -> Fibonacci -> Helix) keeps geometry multi-layered rather than flattened.
->>>>>>>+main
-/codex/organize-project-directory-structure
-- No animation or autoplay; static layering only.
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a temporary local server and open the same files there.
-
-## ND-safe choices
-- No animation or autoplay; only a single draw pass.
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the palette request and displays the inline notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a temporary local server.
-
-## Guards and health checks
-- `.gitattributes` disables LFS filters for PNG to prevent accidental smudging.
-- `.gitignore` blocks `assets/art/black-madonna-altar-1600.png` from returning.
-- `scripts/verify-absent.mjs` exits non-zero if the forbidden PNG reappears. It runs via the `prebuild` npm script and can be invoked manually with `node scripts/verify-absent.mjs`.
-- `core/health-check.html` offers an offline diagnostics page to confirm build timestamp and whether Netlify gating is active.
-
-## ND-safe choices
-- No animation, autoplay, or network dependencies beyond optional manifest fetches (which gracefully fail when offline).
-- Calm contrast, layered order, and generous spacing for readability.
-Edit the file to customize colors. Browsers that support JSON modules (modern Chromium, Firefox, and Safari) will load the palette even when opened via `file://`. Older browsers fall back gracefully while drawing the notice overlay.
-
-## ND-safe choices
-- No animation or autoplay; only a single render pass.
-- Calm contrast, layered order, and generous spacing for readability.
-- Layer hierarchy (Vesica -> Tree -> Fibonacci -> Helix) keeps geometry multi-layered rather than flattened.
-When launched via `file://`, browsers often block local fetches; the renderer therefore skips the palette request and uses the defaults automatically. To preview custom palettes without a server, tweak the defaults in `index.html` and re-open the file.
-
-## ND-safe choices
-- No animation or autoplay; the canvas paints once with layered geometry.
-- Calm contrast, layered order, and generous spacing preserve readability.
-- Layer hierarchy (Vesica → Tree → Fibonacci → Helix) keeps geometry multi-layered rather than flattened.
-Edit the file to customize colors. When launched via `file://`, browsers often block local fetches; the renderer therefore skips the request and displays the inline notice while using the defaults. To preview custom palettes, either adjust the defaults inside `index.html` or launch a temporary local server and open the same files there.
-
-## ND-safe choices
-- No animation or autoplay; only a single canvas render pass.
-- Calm contrast, layered order, and generous spacing for readability.
-- Layer hierarchy (Vesica -> Tree -> Fibonacci -> Helix) keeps geometry multi-layered rather than flattened.
-- Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144` to honor the cosmology brief.
-- Notices appear inside muted panels to communicate fallbacks without flashing or startling color shifts.
-- Octagram fallback and WEBP-only manifest prevent PNG resurrection while keeping the public shell beautiful.
+## ND-safe Choices
+- No animation, no autoplay, no flashing colors.
+- Calm contrast and layered geometry order (Vesica -> Tree -> Fibonacci -> Helix).
+- Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide layout spacing.
+- Inline notices explain fallbacks instead of raising alerts or blocking.

--- a/docs/fly-deployment.md
+++ b/docs/fly-deployment.md
@@ -1,0 +1,37 @@
+# Fly.io Deployment Notes (Manual, Offline-First Prep)
+
+Keep deployments intentional and human-driven. These steps assume you already
+inspected the renderer locally by double-clicking `index.html`.
+
+## 1. Install tooling locally
+- Install [flyctl](https://fly.io/docs/hands-on/install-flyctl/) on your own
+  workstation. Do not automate or script installs inside this repository.
+- Log in from your machine with `flyctl auth login` when you are ready to
+deploy.
+
+## 2. First-time setup
+- From the project root run `flyctl launch --no-deploy` and answer the prompts.
+  - Use an app name that reflects your environment (e.g., `tesseract-bridge`).
+  - Select the `fly.toml` in this repo when asked; it already references the
+    static layout.
+  - Decline volume creation and builders; this site stays static.
+- Commit the generated secrets locally if any were created, but do not push
+  them to version control.
+
+## 3. Deployment
+- Ensure the local files match the desired release. Re-run the renderer locally
+  to confirm palettes and geometry look correct.
+- Deploy with `flyctl deploy --config fly.toml`.
+- After deployment finishes, use `flyctl status` to confirm the static machine is
+  healthy.
+
+## 4. Rollback or updates
+- For updates, repeat the local verification and run `flyctl deploy` again.
+- To rollback, redeploy the previous git tag from your local machine. Fly keeps
+  release history so you can target earlier versions.
+
+## ND-safe reminders
+- Keep assets calm and layered; no animation or auto-playing media.
+- Never enable CDN transformations that could flatten or recolor the geometry.
+- Maintain parity between the offline canvas and the hosted version so sensory
+  expectations remain stable.

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,18 @@
+# Minimal Fly.io config for the static Cosmic Helix renderer.
+# Update the app name locally before first deploy.
+app = "tesseract-bridge"
+
+[build]
+  image = "flyio/static"
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443

--- a/index.html
+++ b/index.html
@@ -2,279 +2,122 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Cathedral of Circuits · Integration Hub</title>
+  <title>Cosmic Helix Renderer (Offline, ND-safe)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe palette: calm contrast, layered depth, no motion */
+    /* ND-safe: gentle contrast, no motion, generous breathing room */
     :root {
-      --bg-primary:#0b0c10;
-      --bg-secondary:#1a1a2e;
-      --ink-primary:#e6e6e6;
-      --ink-secondary:#a9b1ba;
-      --accent-gold:#d4af37;
-      --border-color:#3a3a4a;
+      --bg:#0b0b12;
+      --ink:#e8e8f0;
+      --muted:#a6a6c1;
+      --accent:#d4af37;
+      --border:#1d1d2a;
     }
-    * { margin:0; padding:0; box-sizing:border-box; }
-    html,body { min-height:100vh; background:var(--bg-primary); color:var(--ink-primary); font:15px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { text-align:center; padding:3rem 1rem 2rem; border-bottom:1px solid var(--border-color); background:linear-gradient(135deg,var(--bg-primary),var(--bg-secondary)); }
-    h1 { font-size:2.5rem; color:var(--accent-gold); text-shadow:0 0 20px rgba(212,175,55,0.3); letter-spacing:0.08em; margin-bottom:0.75rem; }
-    .subtitle { color:var(--ink-secondary); font-size:0.95rem; }
-    .status-bar { margin-top:1.5rem; display:flex; flex-wrap:wrap; justify-content:center; gap:1rem; color:var(--ink-secondary); font-size:0.85rem; }
-    main { max-width:1440px; margin:0 auto; padding:2.5rem 1.5rem 4rem; display:flex; flex-direction:column; gap:2.5rem; }
-    .constants-grid { display:flex; justify-content:space-around; flex-wrap:wrap; gap:2rem; padding:2rem; background:var(--bg-secondary); border-radius:10px; border:1px solid var(--border-color); }
-    .constant-item { text-align:center; }
-    .constant-number { display:block; font-size:2.1rem; font-weight:700; color:var(--accent-gold); }
-    .constant-label { margin-top:0.35rem; color:var(--ink-secondary); font-size:0.85rem; text-transform:uppercase; letter-spacing:0.08em; }
-    .section-title { font-size:1.5rem; color:var(--accent-gold); margin-bottom:1rem; text-transform:uppercase; letter-spacing:0.1em; }
-    .note { color:var(--ink-secondary); max-width:960px; margin:0 auto; font-size:0.95rem; line-height:1.6; }
-    .repo-section { display:flex; flex-direction:column; gap:1.2rem; }
-    .repo-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(320px,1fr)); gap:1.6rem; }
-    .repo-card { background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:10px; padding:1.6rem; display:flex; flex-direction:column; gap:0.75rem; position:relative; overflow:hidden; }
-    .repo-card::before { content:""; position:absolute; top:0; left:0; right:0; height:3px; background:var(--accent-gold); transform:scaleX(0); transform-origin:left; transition:transform 0.3s ease; }
-    .repo-card:hover::before { transform:scaleX(1); }
-    .repo-title { font-size:1.3rem; color:var(--accent-gold); display:flex; align-items:center; gap:0.6rem; }
-    .repo-role { color:var(--ink-secondary); font-size:0.9rem; font-style:italic; }
-    .repo-features { list-style:none; display:flex; flex-direction:column; gap:0.4rem; color:var(--ink-secondary); font-size:0.95rem; }
-    .repo-features li { position:relative; padding-left:1.3rem; }
-    .repo-features li::before { content:"✦"; position:absolute; left:0; top:0; color:var(--accent-gold); }
-    .repo-sublist { margin-top:0.35rem; list-style:none; padding-left:1.1rem; display:flex; flex-direction:column; gap:0.25rem; font-size:0.85rem; color:var(--ink-secondary); }
-    .repo-sublist li::before { content:"–"; margin-right:0.35rem; color:var(--ink-secondary); }
-    .repo-links { display:flex; gap:0.8rem; flex-wrap:wrap; }
-    .repo-link { padding:0.45rem 1rem; border-radius:5px; border:1px solid var(--accent-gold); color:var(--accent-gold); text-decoration:none; font-size:0.9rem; transition:background 0.2s ease,color 0.2s ease; }
-    .repo-link:hover, .repo-link:focus { background:var(--accent-gold); color:var(--bg-primary); }
-    .status { display:inline-block; width:9px; height:9px; border-radius:50%; }
-    .status.active { background:#4ade80; }
-    .status.pending { background:#fbbf24; }
-    .status.inactive { background:#ef4444; }
-    .repo-fallback { text-align:center; color:var(--ink-secondary); font-size:0.9rem; }
-    .renderer { display:flex; flex-direction:column; gap:1rem; align-items:center; }
-    #stage { display:block; width:100%; max-width:1440px; height:auto; border:1px solid var(--border-color); box-shadow:0 0 0 1px rgba(0,0,0,0.3); }
-    .instructions { background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:10px; padding:2rem; display:flex; flex-direction:column; gap:1rem; }
-    .instructions ol { padding-left:1.4rem; color:var(--ink-secondary); display:flex; flex-direction:column; gap:0.55rem; }
-    code { background:#11111a; color:var(--accent-gold); padding:0.2rem 0.45rem; border-radius:4px; font-size:0.85rem; }
-    footer { text-align:center; padding:3rem 1rem 4rem; border-top:1px solid var(--border-color); color:var(--accent-gold); font-style:italic; line-height:1.6; font-size:1.1rem; }
-    @media (max-width:768px) {
-      header { padding:2.5rem 1rem; }
-      h1 { font-size:2.1rem; }
-      .status-bar { flex-direction:column; align-items:center; }
-      .constants-grid { padding:1.5rem; }
+    html,body {
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--ink);
+      font:15px/1.5 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
     }
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    /* ND-safe: calm contrast, no motion, layered spacing for readability */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status-list { list-style:none; margin:8px 0 0; padding:0; display:flex; flex-wrap:wrap; gap:12px; font-size:12px; color:var(--muted); }
-    .status-list li { margin:0; }
-    main { max-width:1200px; margin:0 auto; padding:16px; display:flex; flex-direction:column; gap:24px; }
-    #opus, #stage { display:block; margin:0 auto; box-shadow:0 0 0 1px #1d1d2a; }
-    #opus { max-width:100%; height:auto; }
-    #hero-art { min-height:24px; text-align:center; color:var(--muted); font-size:13px; }
-    #hero-art img { display:block; margin:0 auto; max-width:100%; height:auto; }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+    header {
+      padding:16px 20px 12px;
+      border-bottom:1px solid var(--border);
+    }
+    header strong {
+      color:var(--accent);
+      letter-spacing:0.06em;
+    }
+    .status {
+      margin-top:6px;
+      color:var(--muted);
+      font-size:13px;
+    }
+    main {
+      max-width:960px;
+      margin:0 auto;
+      padding:18px 20px 32px;
+      display:flex;
+      flex-direction:column;
+      gap:18px;
+    }
+    #stage {
+      display:block;
+      width:100%;
+      max-width:1440px;
+      height:auto;
+      border:1px solid var(--border);
+      box-shadow:0 0 0 1px #11111a;
+    }
+    .note {
+      color:var(--muted);
+      font-size:0.95rem;
+    }
+    .note strong {
+      color:var(--accent);
+    }
+    footer {
+      margin-top:16px;
+      padding-top:12px;
+      border-top:1px solid var(--border);
+      color:var(--muted);
+      font-size:12px;
+      line-height:1.6;
+    }
+    code {
+      background:#11111a;
+      color:var(--accent);
+      padding:0 4px;
+      border-radius:3px;
+    }
   </style>
 </head>
 <body>
   <header>
-<<<<<    <h1>✦ Cathedral of Circuits ✦</h1>
-    <p class="subtitle">ND-safe · Provenance required · Layered geometry · Offline-first bridge</p>
-    <div class="status-bar" role="status" aria-live="polite">
-      <span id="status">Loading palette…</span>
-      <span id="manifest-status">Loading bridge manifest…</span>
-    </div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline)</div>
+    <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
   </header>
 
   <main>
-    <section class="constants-grid" aria-label="Sacred constants">
-      <div class="constant-item"><span class="constant-number">0-144</span><span class="constant-label">All combinations</span></div>
-      <div class="constant-item"><span class="constant-number">72</span><span class="constant-label">Angels</span></div>
-      <div class="constant-item"><span class="constant-number">72</span><span class="constant-label">Demons</span></div>
-      <div class="constant-item"><span class="constant-number">33</span><span class="constant-label">Spine chapters</span></div>
-      <div class="constant-item"><span class="constant-number">78</span><span class="constant-label">Tarot arcana</span></div>
-    </section>
-
-    <section class="repo-section" aria-labelledby="integration-hub-title">
-      <h2 id="integration-hub-title" class="section-title">Integration Hub</h2>
-      <p class="note">Cards below assemble directly from <code>registry/notes/bridge_manifest.json</code>. This keeps provenance intact, prevents hardcoded lists, and preserves layered context for every realm.</p>
-      <div id="repo-grid" class="repo-grid" aria-live="polite"></div>
-      <p id="repo-fallback" class="repo-fallback">Bridge manifest loading…</p>
-    </section>
-
-    <section class="renderer" aria-labelledby="renderer-title">
-      <h2 id="renderer-title" class="section-title">Cosmic Helix Renderer</h2>
-      <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-      <p class="note">Offline canvas renders Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. No animation, no autoplay. If supporting data go missing, the renderer annotates the canvas with a calm notice while staying ND-safe.</p>
-    </section>
-
-    <section class="instructions" aria-labelledby="protocol-title">
-      <h2 id="protocol-title" class="section-title">Deployment protocol</h2>
-      <ol>
-        <li>Clone each repository and align shared files from the blueprint archives.</li>
-        <li>Place master images in <code>assets/raw/</code> (PNG/JPG only).</li>
-        <li>Run <code>npm install</code> then <code>npm run build</code> for local confidence checks.</li>
-        <li>Deploy manually to Netlify with <code>netlify deploy --prod --build</code> (no automated workflows).</li>
-        <li>Disable image optimization in Netlify UI to keep layered geometry intact.</li>
-        <li>Update <code>registry/realm_links.json</code> with live endpoints once verified.</li>
-        <li>Confirm <code>/core/health-check.html</code> responds with 200 for each realm.</li>
-        <li>Add new nodes or combinations to <code>registry/nodes.json</code> respecting schema and numerology counts.</li>
-        <li>For content updates, bump <code>SW_VERSION</code> inside <code>public/sw.js</code> before shipping.</li>
-      </ol>
-    </section>
-  </main>
-
-  <footer>
-    "In sacred pattern, healing is found. In open spiral, truth may be chosen. In the Codex, all is remembered."
-  </footer>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
->>>>>>>+main
-ng>Cosmi    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
->>>>>>>+main/codex/orga
-tic renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
-    <ul class="status-list">
-      <li id="status">Loading palette...</li>
-      <li id="hero-status">Preparing hero art fallback...</li>
-    </ul>
-  </header>
-
-  <main>
-    <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
-    <div id="hero-art" aria-live="polite">Hero art pending.</div>
     <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-    <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+    <p class="note">
+      The canvas renders four static layers: <strong>Vesica field</strong>, <strong>Tree-of-Life nodes and paths</strong>,
+      <strong>Fibonacci curve</strong>, and a <strong>static double-helix lattice</strong>. No animation, no autoplay, and
+      no external dependencies. Open this file directly for an offline, ND-safe scene.
+    </p>
+    <footer>
+      Numerology anchors: 3, 7, 9, 11, 22, 33, 99, 144. Geometry stays multi-layered and calm to honor the Cathedral brief.
+    </footer>
   </main>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
-    import { paintOctagram } from "./assets/js/first-paint-octagram.js";
-    import { mountArt } from "./assets/js/art-loader.js";
 
-    const paletteStatus = document.getElementById("status");
-    const manifestStatus = document.getElementById("manifest-status");
-    const repoGrid = document.getElementById("repo-grid");
-    const repoFallback = document.getElementById("repo-fallback");
+    const status = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
-    const heroStatus = document.getElementById("hero-status");
-    const heroHost = document.getElementById("hero-art");
-    const stageCanvas = document.getElementById("stage");
-    const stageCtx = stageCanvas.getContext("2d");
 
-    paintOctagram();
-
-    const notices = [];
-    const heroMessages = new Set();
-
-    function noteHeroFallback(message) {
-      if (heroHost) {
-        heroHost.textContent = message;
-      }
-      if (!heroMessages.has(message)) {
-        notices.push(message);
-        heroMessages.add(message);
-      }
-    }
-
-    const heroResult = await mountArt({
-      manifestPath: "./assets/art/manifest.json",
-      targetId: "hero-art",
-      statusElement: heroStatus,
-      onFallback: noteHeroFallback
-    });
-
-    if (!heroResult && heroHost && heroMessages.size === 0) {
-      noteHeroFallback("Hero art offline; octagram fallback on duty.");
-    }
-
-    const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-    const elStatus = document.getElementById("status");
-    const canvas = document.getElementById("stage");
-    const ctx = canvas ? canvas.getContext("2d") : null;
-    const notices = [];
-
-    async fun    async function loadJSON(path) {
-      /*
-        Offline covenant: skip fetch when opened via file:// so no network requests fire.
-        When served over http(s) the fetch stays local and still honors the no-dependency rule.
-      */
-      if (typeof window === "undefined" || !window.fetch || (window.location && window.location.protocol === "file:")) {
-
-    async function loadJSON(path) {
-      // ND-safe guard: avoid network requests when opened via file://
-    async function loadJSON(path) {
-      // Offline assurance: skip fetch entirely when opened via file:// to avoid blocked network calls.
-    async function loadPalette(path, noticeList) {
-      if (typeof window !== "undefined" && window.location && window.location.protocol === "file:") {
-        if (Array.isArray(noticeList)) noticeList.push("Palette fetch skipped for file:// launch; calm defaults engaged.");
-        return null;
-      }
-    };
-
-    const REPO_OVERRIDES = {
-      "stone-cathedral": {
-        title:"Stone Grimoire",
-        site:"https://stone-grimoire.netlify.app",
-        source:"https://github.com/yourusername/stone-grimoire"
     async function loadPalette(path) {
-      if (typeof window !== "undefined" && window.location && window.location.protocol === "file:") {
-        return { data: null, reason: "file-protocol" };
-      }
-      try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) {
-          return { data: null, reason: "http-" + res.status };
-        }
-        return { data: await res.json(), reason: "loaded" };
-      } catch (err) {
-        return { data: null, reason: "fetch-error" };
-          if (Array.isArray(noticeList)) noticeList.push("Palette fetch returned status " + res.status + "; using defaults.");
-          return null;
-        }
-        return await res.json();
-      } catch (err) {
-        if (Array.isArray(noticeList)) noticeList.push("Palette fetch failed; using defaults.");
+      /*
+        Offline-first loader: skips fetch when opened via file:// to avoid noisy console errors.
+        Returns null on failure so the renderer can fall back to calm defaults.
+      */
+      if (window.location.protocol === "file:") {
         return null;
       }
-    };
+      try {
+        const response = await fetch(path, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(String(response.status));
+        }
+        return await response.json();
+      } catch (error) {
+        console.warn(`Palette load failed: ${error.message}`);
+        return null;
+      }
+    }
 
-    const STATUS_CLASS = new Map([
-      ["source-of-truth","active"],
-      ["active","active"],
-      ["reference","active"],
-      ["pending-merge","pending"],
-      ["draft","pending"],
-      ["inactive","inactive"]
-    ]);
     const defaults = {
       palette: {
         bg:"#0b0b12",
@@ -282,475 +125,34 @@ tic renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix 
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
       }
     };
->>>>>>>+main
- = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
->>>>>>> main/codex/organize-project-directory-structure
 
-    async function loadPaletteModule(path) {
-      /*
-        Offline-first: JSON module import avoids network fetches.
-        Missing files or unsupported JSON modules fall back to defaults.
-      */
-      const result = {
-        palette: null,
-        statusText: "Palette missing; using safe fallback.",
-        notices: []
-      };
-      try {
-        const module = await import(path, { assert: { type: "json" } });
-        if (module && module.default && typeof module.default === "object") {
-          result.palette = module.default;
-          result.statusText = "Palette loaded.";
-        } else {
-          result.notices.push("Palette module invalid; calm defaults engaged.");
-        }
-      } catch (error) {
-        result.notices.push("Palette JSON unavailable or unsupported; calm defaults engaged.");
-      }
-      return result;
-    }
-
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-    function mergePalette(defaultPalette, overridePalette, notices) {
-      const base = { ...defaultPalette, layers:[...defaultPalette.layers] };
-    function buildPalette(defaultPalette, overridePalette, notices) {
-      const base = { ...defaultPalette, layers: [...defaultPalette.layers] };
-      if (!overridePalette || typeof overridePalette !== "object") {
-        paletteNotices.push("Palette missing; defaults preserved.");
-    function sanitizePalette(defaultPalette, overridePalette, paletteNotices) {
-      // Pure function: clones defaults, applies overrides when valid, records calm notices otherwise.
-    function mergePalette(defaultPalette, overridePalette, noticeList) {
-    function mergePalette(defaultPalette, overridePalette, log) {
-      const base = { ...defaultPalette, layers: [...defaultPalette.layers] };
-      if (!overridePalette || typeof overridePalette !== "object") {
-        if (overridePalette !== null && overridePalette !== undefined) {
-          paletteNotices.push("Palette object invalid; defaults retained.");
-        }
-        return base;
-      }
-      if (typeof overridePalette.bg === "string") {
-        base.bg = overridePalette.bg;
-      } else {
-        notices.push("Palette missing bg; using default.");
-      } else if (overridePalette.bg !== undefined) {
-        notices.push("Palette bg invalid; using default.");
-      } else if (overridePalette.bg !== undefined) {
-        paletteNotices.push("Palette bg invalid; using default.");
-      } else if (overridePalette.bg !== undefined) {
-        paletteNotices.push("Palette bg invalid; default shade kept.");
-      } else if (overridePalette.bg !== undefined) {
-        if (Array.isArray(noticeList)) noticeList.push("Palette bg invalid; default retained.");
-        log.push("Palette missing bg; using default.");
-      }
-      if (typeof overridePalette.ink === "string") {
-        base.ink = overridePalette.ink;
-      } else {
-        notices.push("Palette missing ink; using default.");
-      } else if (overridePalette.ink !== undefined) {
-        notices.push("Palette ink invalid; using default.");
-      } else if (overridePalette.ink !== undefined) {
-        paletteNotices.push("Palette ink invalid; using default.");
-      } else if (overridePalette.ink !== undefined) {
-        paletteNotices.push("Palette ink invalid; default ink kept.");
-      } else if (overridePalette.ink !== undefined) {
-        if (Array.isArray(noticeList)) noticeList.push("Palette ink invalid; default retained.");
-        log.push("Palette missing ink; using default.");
-      }
-      if (Array.isArray(overridePalette.layers)) {
-        for (let i = 0; i < base.layers.length; i += 1) {
-          if (typeof overridePalette.layers[i] === "string") {
-            base.layers[i] = overridePalette.layers[i];
-          } else if (overridePalette.layers[i] !== undefined) {
-            log.push("Palette layer " + (i + 1) + " invalid; using default.");
-          }
-        }
-      } else {
-        notices.push("Palette layers missing; using defaults.");
-      } else if (overridePalette.layers !== undefined) {
-        notices.push("Palette layers invalid; using defaults.");
-      } else if (overridePalette.layers !== undefined) {
-        paletteNotices.push("Palette layers invalid; using defaults.");
-            paletteNotices.push("Palette layer " + (i + 1) + " invalid; default used.");
-          }
-        }
-      } else if (overridePalette.layers !== undefined) {
-        paletteNotices.push("Palette layers invalid; defaults used.");
-            if (Array.isArray(noticeList)) noticeList.push("Palette layer " + (i + 1) + " invalid; default retained.");
-          }
-        }
-      } else if (overridePalette.layers !== undefined) {
-        if (Array.isArray(noticeList)) noticeList.push("Palette layers invalid; defaults retained.");
-        log.push("Palette layers missing; using defaults.");
-      }
-      return base;
-    }
-
-    function formatTitle(repoId) {
-      const override = REPO_OVERRIDES[repoId];
-      if (override && override.title) {
-        return override.title;
-      }
-      const pretty = repoId
-        .replace(/-/g, " ")
-        .replace(/([a-zA-Z])(\d)/g, "$1 $2");
-      return pretty.split(" ").filter(Boolean).map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1)).join(" ");
-    }
-
-    function resolveLink(repoId, type) {
-      const override = REPO_OVERRIDES[repoId];
-      if (override && override[type]) {
-        return override[type];
-      }
-      if (type === "site") {
-        return "https://" + repoId + ".netlify.app";
-      }
-      return "https://github.com/yourusername/" + repoId;
-    }
-
-    function statusClass(status) {
-      return STATUS_CLASS.get(status) || "pending";
-    }
-
-    function formatList(values) {
-      if (!Array.isArray(values) || values.length === 0) {
-        return "None recorded";
-      }
-      return values.join(", ");
-    }
-
-    function createNextActionsList(nextActions) {
-      const sublist = document.createElement("ul");
-      sublist.className = "repo-sublist";
-      nextActions.forEach((action) => {
-        const item = document.createElement("li");
-        item.textContent = action;
-        sublist.appendChild(item);
-      });
-      return sublist;
-    }
-
-    function createRepoCard(repo) {
-      const card = document.createElement("article");
-      card.className = "repo-card";
-
-      const title = document.createElement("h3");
-      title.className = "repo-title";
-      title.textContent = formatTitle(repo.id);
-      const statusDot = document.createElement("span");
-      statusDot.className = "status " + statusClass(repo.status);
-      statusDot.title = repo.status;
-      title.appendChild(statusDot);
-
-      const role = document.createElement("p");
-      role.className = "repo-role";
-      role.textContent = repo.role || "Role undocumented";
-
-      const features = document.createElement("ul");
-      features.className = "repo-features";
-      const linkedIds = document.createElement("li");
-      linkedIds.textContent = "Linked IDs: " + formatList(repo.linked_ids);
-      features.appendChild(linkedIds);
-
-      if (Array.isArray(repo.bridges) && repo.bridges.length > 0) {
-        repo.bridges.forEach((bridge) => {
-          const focus = Array.isArray(bridge.focus) ? bridge.focus.join(", ") : "Focus pending";
-          const bridgeItem = document.createElement("li");
-          bridgeItem.textContent = "Bridge → " + formatTitle(bridge.id) + ": " + focus;
-          if (Array.isArray(bridge.next_actions) && bridge.next_actions.length > 0) {
-            bridgeItem.appendChild(createNextActionsList(bridge.next_actions));
-          }
-          features.appendChild(bridgeItem);
-        });
-      }
-
-      if (repo.notes) {
-        const noteItem = document.createElement("li");
-        noteItem.textContent = repo.notes;
-        features.appendChild(noteItem);
-      }
-
-      const linksContainer = document.createElement("div");
-      linksContainer.className = "repo-links";
-      const siteLink = document.createElement("a");
-      siteLink.className = "repo-link";
-      siteLink.href = resolveLink(repo.id, "site");
-      siteLink.target = "_blank";
-      siteLink.rel = "noopener noreferrer";
-      siteLink.textContent = "Visit site";
-      linksContainer.appendChild(siteLink);
-
-      const repoLink = document.createElement("a");
-      repoLink.className = "repo-link";
-      repoLink.href = resolveLink(repo.id, "source");
-      repoLink.target = "_blank";
-      repoLink.rel = "noopener noreferrer";
-      repoLink.textContent = "GitHub";
-      linksContainer.appendChild(repoLink);
-
-      card.appendChild(title);
-      card.appendChild(role);
-      card.appendChild(features);
-      card.appendChild(linksContainer);
-      return card;
-    async function loadPaletteJSON(noticesList) {
-      /*
-        Offline assurance: honor the "no network" brief by avoiding fetch while
-        running as file://. When the palette cannot be reached the calm defaults
-        remain, and a notice will be rendered on-canvas.
-      */
-      const protocol = typeof window !== "undefined" && window.location ? window.location.protocol : null;
-      if (protocol === "file:") {
-        noticesList.push("Local file mode blocks palette fetch; calm defaults engaged.");
-        return null;
-      }
-    async function loadPaletteJSON(noticesList) {
-      /*
-        Offline assurance: honor the "no network" brief by avoiding fetch while
-        running as file://. When the palette cannot be reached the calm defaults
-        remain, and a notice will be rendered on-canvas.
-      */
-      const protocol = typeof window !== "undefined" && window.location ? window.location.protocol : null;
-      if (protocol === "file:") {
-        noticesList.push("Local file mode blocks palette fetch; calm defaults engaged.");
-        return null;
-      }
-      try {
-        const res = await fetch("./data/palette.json", { cache: "no-store" });
-        if (!res.ok) {
-          throw new Error(String(res.status));
-        }
-        return await res.json();
-      } catch (err) {
-        noticesList.push("Palette JSON unavailable (" + err.message + "); calm defaults engaged.");
-        return null;
-      }
-    }
-
-<<<<<<< main
-    const paletteNotices = [];
-    const paletteOverride = await loadPaletteJSON(paletteNotices);
-    const active = mergePalette(defaults.palette, paletteOverride, paletteNotices);
-
-    document.documentElement.style.setProperty("--bg", active.bg);
-    document.documentElement.style.setProperty("--ink", active.ink);
-
-    if (paletteOverride) {
-      elStatus.textContent = "Palette loaded.";
-    } else {
-      elStatus.textContent = "Palette fallback active.";
-    const paletteNotices = [];
-    const paletteResult = await loadPalette("./data/palette.json");
-    const active = mergePalette(defaults.palette, paletteResult.data, paletteNotices);
-
-    if (paletteResult.reason === "loaded") {
-      if (elStatus) elStatus.textContent = "Palette loaded.";
-    } else {
-      if (elStatus) elStatus.textContent = "Palette missing; using safe fallback.";
-      if (paletteResult.reason === "file-protocol") {
-        paletteNotices.push("Running from file:// so palette fetch is skipped. Calm defaults applied.");
-      } else if (paletteResult.reason && paletteResult.reason.startsWith("http-")) {
-        paletteNotices.push("Palette JSON responded with " + paletteResult.reason + "; calm defaults applied.");
-      } else if (paletteResult.reason === "fetch-error") {
-        paletteNotices.push("Palette JSON not available; calm defaults engaged.");
-      }
-    }
-
-    function populateRepoGrid(repos) {
-      repoGrid.innerHTML = "";
-      if (!Array.isArray(repos) || repos.length === 0) {
-        repoFallback.textContent = "Bridge manifest contained no repos; add entries to registry/notes/bridge_manifest.json.";
-        return;
-      }
-      repos.forEach((repo) => {
-        repoGrid.appendChild(createRepoCard(repo));
-      });
-      repoFallback.textContent = "";
-    }
-
-    async function loadPalette() {
-      const notices = [];
-      try {
-        const module = await import("./data/palette.json", { assert:{ type:"json" } });
-        if (paletteStatus) {
-          paletteStatus.textContent = "Palette loaded.";
-        }
-        return { palette: module.default, notices };
-      } catch (error) {
-        notices.push("Palette JSON not available; calm defaults engaged.");
-        if (paletteStatus) {
-          paletteStatus.textContent = "Palette missing; using safe fallback.";
-        }
-        return { palette: null, notices };
-      }
-    }
-
-    async function loadManifest() {
-      try {
-        const module = await import("./registry/notes/bridge_manifest.json", { assert:{ type:"json" } });
-        const manifest = module.default;
-        if (manifestStatus) {
-          const stamp = manifest.last_updated ? "Last updated " + manifest.last_updated : "Bridge manifest loaded.";
-          manifestStatus.textContent = stamp;
-        }
-        populateRepoGrid(manifest.repos);
-        return [];
-      } catch (error) {
-        const message = "Bridge manifest missing; hub cards in fallback mode.";
-        if (manifestStatus) {
-          manifestStatus.textContent = message;
-        }
-        repoFallback.textContent = message + " Update registry/notes/bridge_manifest.json to restore details.";
-        return [message];
-      }
     const notices = [];
-    const palette = await loadJSON("./data/palette.json");
-    const active = buildPalette(defaults.palette, palette, notices);
+    const palette = await loadPalette("./data/palette.json");
     if (palette) {
-      elStatus.textContent = "Palette loaded.";
+      status.textContent = "Palette loaded.";
     } else {
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      notices.push("Palette JSON unavailable; calm defaults engaged.");
-    const paletteData = await loadPalette("./data/palette.json", notices);
-    const active = mergePalette(defaults.palette, paletteData, notices);
-
-    if (paletteData) {
-      if (elStatus) elStatus.textContent = "Palette loaded.";
-    } else {
-      if (elStatus) elStatus.textContent = "Palette missing; using safe fallback.";
-      notices.push("Palette JSON not available; calm defaults engaged.");
+      status.textContent = "Palette missing; using calm fallback.";
+      notices.push("Palette file offline - defaults applied for ND-safe contrast.");
     }
 
-    async function main() {
-      const notices = [];
-      const paletteResult = await loadPalette();
-      const palette = mergePalette(defaults.palette, paletteResult.palette, paletteResult.notices);
-      notices.push(...paletteResult.notices);
-      const manifestNotices = await loadManifest();
-      notices.push(...manifestNotices);
+    const NUM = {
+      THREE:3,
+      SEVEN:7,
+      NINE:9,
+      ELEVEN:11,
+      TWENTYTWO:22,
+      THIRTYTHREE:33,
+      NINETYNINE:99,
+      ONEFORTYFOUR:144
+    };
 
-      if (!ctx) {
-        if (paletteStatus) {
-          paletteStatus.textContent = "2D canvas context unavailable.";
-        }
-        return;
-      }
-
-      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette, NUM, notices });
-    } else {
-      elStatus.textContent = "Palette fallback active.";
-    const palette = await loadJSON("./data/palette.json");
-    const paletteNotices = [];
-    const active = sanitizePalette(defaults.palette, palette, paletteNotices);
-
-    if (palette && paletteNotices.length === 0) {
-      elStatus.textContent = "Palette loaded.";
-    } else if (palette && paletteNotices.length > 0) {
-      elStatus.textContent = "Palette adjusted; see notice.";
-      notices.push(...paletteNotices);
-    } else {
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      if (paletteNotices.length > 0) {
-        notices.push(...paletteNotices);
-      }
-      notices.push("Palette JSON not available; calm defaults engaged.");
-    }
-
-    main();
-    if (!ctx) {
-      elStatus.textContent = "2D canvas context unavailable.";
-      elStatus.textContent = "2D context unavailable.";
-    const paletteData = await loadJSON("./data/palette.json");
-    const activePalette = mergePalette(defaults.palette, paletteData, notices);
-
-    if (paletteData) {
-      paletteStatus.textContent = "Palette loaded.";
-    } else {
-      paletteStatus.textContent = "Palette missing; using safe fallback.";
-      notices.push("Palette JSON not available; calm defaults engaged.");
-    }
-
-    if (!stageCtx) {
-      paletteStatus.textContent = "2D canvas context unavailable.";
-      notices.push("Canvas context unavailable; nothing rendered.");
-    } else {
-      // Numerology constants used by geometry routines
-      const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-      // ND-safe rationale: no motion, high readability, soft colors, layered order
-      notices.push("Canvas context unavailable; geometry not rendered.");
-    }
-    async function main() {
-      if (!canvas) {
-        if (elStatus) elStatus.textContent = "Canvas element missing.";
-        return;
-      }
-
-      const ctx = canvas.getContext("2d");
-      if (!ctx) {
-        if (elStatus) elStatus.textContent = "2D canvas context unavailable.";
-        return;
-      }
-
-      const defaults = {
-        palette: {
-          bg:"#0b0b12",
-          ink:"#e8e8f0",
-          layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-        }
-      };
-
-      const loadResult = await loadPaletteModule("./data/palette.json");
-      const paletteNotices = [...loadResult.notices];
-      const activePalette = mergePalette(defaults.palette, loadResult.palette, paletteNotices);
-
-      if (elStatus) {
-        elStatus.textContent = loadResult.statusText;
-      }
-
-      const NUM = {
-        THREE:3,
-        SEVEN:7,
-        NINE:9,
-        ELEVEN:11,
-        TWENTYTWO:22,
-        THIRTYTHREE:33,
-        NINETYNINE:99,
-        ONEFORTYFOUR:144
-      };
-
-      // ND-safe rationale: no motion, high readability, layered depth maintained
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM,
-        notices: paletteNotices
-      });
-    }
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    if (ctx) {
-
-      // ND-safe rationale: no motion, high readability, soft colors, layered order
-      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices:[...notices, ...paletteNotices] });
-
-      // ND-safe rationale: no motion, high readability, soft colors, layered order
-      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices });
-    }
-    main();
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices });
-
-      // ND-safe rationale: no motion, high readability, soft colors, layered order
-      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notices });
-    }
-    renderHelix(stageCtx, { width:stageCanvas.width, height:stageCanvas.height, palette:activePalette, NUM, notices });
+    renderHelix(ctx, {
+      width:canvas.width,
+      height:canvas.height,
+      palette:palette || defaults.palette,
+      NUM,
+      notices
+    });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -13,18 +13,40 @@
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM, notices = [] }) {
+  const safePalette = normalizePalette(palette);
+
   // ND-safe background: calm tone, no flashing or gradients
   ctx.save();
-  ctx.fillStyle = palette.bg;
+  ctx.fillStyle = safePalette.bg;
   ctx.fillRect(0, 0, width, height);
 
   // Draw layered geometry back-to-front to preserve depth without animation
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
-  drawNotices(ctx, width, height, palette.ink, notices);
+  drawVesica(ctx, width, height, safePalette.layers[0], NUM);
+  drawTreeOfLife(ctx, width, height, safePalette.layers[1], safePalette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, safePalette.layers[3], NUM);
+  drawHelix(ctx, width, height, safePalette.layers[4], safePalette.layers[5], NUM);
+  drawNotices(ctx, width, height, safePalette.ink, notices);
   ctx.restore();
+}
+
+function normalizePalette(palette) {
+  /*
+    Ensures every render uses calm, ND-safe colors even when the palette file is
+    missing or partially defined. Layers fall back in order without flashing.
+  */
+  const defaults = {
+    bg: "#0b0b12",
+    ink: "#e8e8f0",
+    layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+  };
+  const source = palette ?? {};
+  const incomingLayers = Array.isArray(source.layers) ? source.layers : [];
+  const layers = defaults.layers.map((fallback, index) => incomingLayers[index] ?? fallback);
+  return {
+    bg: source.bg ?? defaults.bg,
+    ink: source.ink ?? defaults.ink,
+    layers
+  };
 }
 
 // --- Layer 1: Vesica field -------------------------------------------------

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[build]
-  command = ""
-  publish = "/"
-
-[build.environment]
-  GIT_LFS_ENABLED = "false"
-  GIT_LFS_SKIP_SMUDGE = "1"

--- a/scripts/verify-absent.mjs
+++ b/scripts/verify-absent.mjs
@@ -1,23 +1,20 @@
-// ND-safe, fail-closed guard for forbidden files
-import { existsSync } from "node:fs";
-
-const tombs = ["img/black-madonna.png"];
-const risen = tombs.filter((p) => existsSync(p));
-
-if (risen.length) {
 /*
   verify-absent.mjs
-  ND-safe guard: ensures forbidden PNG assets stay absent to prevent accidental resurrection.
+  ND-safe guard: ensure forbidden PNG assets stay buried.
 */
 
 import { existsSync } from "node:fs";
 
-const tombs = ["assets/art/black-madonna-altar-1600.png"];
+const tombs = [
+  "assets/art/black-madonna-altar-1600.png",
+  "img/black-madonna.png"
+];
+
 const risen = tombs.filter((path) => existsSync(path));
 
 if (risen.length > 0) {
-  console.error("PROTECT violation: undead asset(s) present:", risen);
+  console.error("PROTECT violation: undead asset(s) present:", risen.join(", "));
   process.exit(1);
-} else {
-  console.log("Guard ok — no undead assets detected.");
 }
+
+console.log("Guard ok - no undead assets detected.");


### PR DESCRIPTION
## Summary
- replace the sprawling index with a lightweight ND-safe canvas scene and explicit palette fallbacks
- normalize renderer color handling, refresh documentation, and outline manual Fly.io deployment steps
- remove Netlify config, add fly.toml, and repair the offline guard script for forbidden assets

## Testing
- npm run prebuild

------
https://chatgpt.com/codex/tasks/task_e_68cf8f43d14c8328acd38ef7662cacf3