### PR TITLE
Document canon mapping in renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -44,3 +44,12 @@ external dependencies.
 - Calm contrast, layered order, and generous spacing for readability.
 - Geometry counts align with numerology constants `3, 7, 9, 11, 22, 33, 99, 144`
   to honor the cosmology brief.
+
+## Canon integration (why these layers)
+- **Soul — circuitum99:** Vesica field keeps light wells intersecting without
+  collapse.
+- **Mind — cosmogenesis-learning-engine:** Tree-of-Life lattice carries study
+  pathways.
+- **Body — stone-cathedral:** Fibonacci spiral threads embodied expansion.
+- **Tarot — liber-arcanae:** Double helix preserves divination memory in static
+  braids.

--- a/index.html
+++ b/index.html
@@ -85,8 +85,11 @@
     <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
     <p class="note">
       The canvas renders four static layers: <strong>Vesica field</strong>, <strong>Tree-of-Life nodes and paths</strong>,
-      <strong>Fibonacci curve</strong>, and a <strong>static double-helix lattice</strong>. No animation, no autoplay, and
-      no external dependencies. Open this file directly for an offline, ND-safe scene.
+      <strong>Fibonacci curve</strong>, and a <strong>static double-helix lattice</strong>. Each layer pairs with the canon
+      anchors — Soul (<code>circuitum99</code>) for the Vesica field, Mind (<code>cosmogenesis-learning-engine</code>) for the
+      Tree-of-Life scaffold, Body (<code>stone-cathedral</code>) for the Fibonacci sweep, and Tarot (<code>liber-arcanae</code>) for
+      the helix lattice. No animation, no autoplay, and no external dependencies. Open this file directly for an offline,
+      ND-safe scene.
     </p>
     <footer>
       Numerology anchors: <code>3</code>, <code>7</code>, <code>9</code>, <code>11</code>, <code>22</code>, <code>33</code>, <code>99</code>, <code>144</code>.

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -8,6 +8,12 @@
     3) Fibonacci curve - static logarithmic spiral polyline
     4) Double-helix lattice - two phase-shifted strands with crossbars
 
+  Canon alignment (why the order matters):
+    - Soul / circuitum99: Vesica field establishes the luminous soul grid.
+    - Mind / cosmogenesis-learning-engine: Tree-of-Life articulates study paths.
+    - Body / stone-cathedral: Fibonacci curve threads embodied growth.
+    - Tarot / liber-arcanae: Double helix anchors divination memory lattice.
+
   Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
   Every routine is pure: all state flows through parameters.
 */
@@ -85,6 +91,7 @@ function drawVesica(ctx, w, h, color, NUM) {
   /*
     Intersecting circle grid referencing 9 columns and 7 rows.
     Total circles (9 * 7 * 2 = 126) stay below the 144 threshold for sensory ease.
+    Canon link: Soul / circuitum99 is rendered as overlapping light wells.
   */
   const cols = NUM.NINE;
   const rows = NUM.SEVEN;
@@ -113,6 +120,7 @@ function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, NUM) {
   /*
     Ten sephirot nodes (Tree of Life) and twenty-two connecting paths.
     Positions are normalized to keep structure centered and balanced.
+    Canon link: Mind / cosmogenesis-learning-engine forms the studious lattice.
   */
   const nodesNorm = [
     [0.50, 0.08], // Keter
@@ -158,6 +166,7 @@ function drawFibonacci(ctx, w, h, color, NUM) {
   /*
     Static logarithmic spiral approximated with NUM.NINETYNINE segments.
     Center offset toward the lower left to weave between Vesica and Helix layers.
+    Canon link: Body / stone-cathedral anchors the growth spiral.
   */
   const phi = (1 + Math.sqrt(5)) / 2;
   const quarterTurns = NUM.THREE; // three quarter-turns for gentle sweep
@@ -190,6 +199,7 @@ function drawHelix(ctx, w, h, colorA, colorB, NUM) {
   /*
     Two static sine-based strands with TWENTYTWO crossbars to echo the paths.
     Amplitude kept small for visual calm while preserving layered depth.
+    Canon link: Tarot / liber-arcanae holds the helix archive without motion.
   */
   const segments = NUM.ONEFORTYFOUR;
   const amplitude = h / NUM.NINE;


### PR DESCRIPTION
## Summary
- highlight the canon-to-layer mapping directly in the renderer documentation and inline comments
- annotate each drawing routine with the associated cosmology anchor for clarity
- explain canon integration in the renderer README so the lore stays intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72e57caf48328b6789ad2128a9620